### PR TITLE
dependency management (beta)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+### Added
+
+- `dbt deps` pulls dependents specified in the `repositories` key
+the project config into the compile path

--- a/dbt/main.py
+++ b/dbt/main.py
@@ -16,7 +16,7 @@ def main(args=None):
     if os.path.isfile('dbt_project.yml'):
         proj = project.read_project('dbt_project.yml')
     else:
-        proj = project.default_project()
+        raise RuntimeError("dbt must be run from a project root directory with a dbt_project.yml file")
 
     p = argparse.ArgumentParser(prog='dbt: data build tool')
     subs = p.add_subparsers()

--- a/dbt/main.py
+++ b/dbt/main.py
@@ -6,6 +6,7 @@ import dbt.task.run as run_task
 import dbt.task.compile as compile_task
 import dbt.task.debug as debug_task
 import dbt.task.clean as clean_task
+import dbt.task.deps as deps_task
 
 
 def main(args=None):
@@ -23,14 +24,17 @@ def main(args=None):
     sub = subs.add_parser('clean')
     sub.set_defaults(cls=clean_task.CleanTask)
 
-    sub = subs.add_parser('run')
-    sub.set_defaults(cls=run_task.RunTask)
-
     sub = subs.add_parser('compile')
     sub.set_defaults(cls=compile_task.CompileTask)
 
     sub = subs.add_parser('debug')
     sub.set_defaults(cls=debug_task.DebugTask)
+
+    sub = subs.add_parser('deps')
+    sub.set_defaults(cls=deps_task.DepsTask)
+
+    sub = subs.add_parser('run')
+    sub.set_defaults(cls=run_task.RunTask)
 
     parsed = p.parse_args(args)
 

--- a/dbt/project.py
+++ b/dbt/project.py
@@ -62,7 +62,7 @@ class Project:
     def context(self):
         target_cfg = self.run_environment()
         filtered_target = copy.deepcopy(target_cfg)
-        filtered_target.pop('pass')
+        filtered_target.pop('pass', None)
         return {'env': target_cfg}
 
     def with_profiles(self, profiles=[]):
@@ -85,17 +85,9 @@ def read_profiles():
 
     return profiles
 
-
-def init_project(project_cfg):
-    profiles = read_profiles()
-    return Project(project_cfg, profiles, default_active_profiles)
-
-
 def read_project(filename):
     with open(filename, 'r') as f:
-        cfg = yaml.safe_load(f)
-        return init_project(cfg)
-
-
-def default_project():
-    return init_project(default_project_cfg)
+        project_cfg = yaml.safe_load(f)
+        project_cfg['project-root'] = os.path.dirname(os.path.abspath(filename))
+        profiles = read_profiles()
+        return Project(project_cfg, profiles, default_active_profiles)

--- a/dbt/project.py
+++ b/dbt/project.py
@@ -12,9 +12,11 @@ default_project_cfg = {
     'run-target': 'default',
     'models': {},
     'model-defaults': {
-        "enabled": True,
-        "materialized": False
-    }
+        'enabled': True,
+        'materialized': False
+    },
+    'repositories': [],
+    'modules-path': 'dbt_modules'
 }
 
 default_profiles = {

--- a/dbt/task/compile.py
+++ b/dbt/task/compile.py
@@ -3,6 +3,7 @@ import os
 import fnmatch
 import jinja2
 import yaml
+import dbt.project
 from collections import defaultdict
 
 class CompileTask:
@@ -10,19 +11,20 @@ class CompileTask:
         self.args = args
         self.project = project
 
-    def __src_index(self):
+    def __project_sources(self, project):
         """returns: {'model': ['pardot/model.sql', 'segment/model.sql']}
         """
         indexed_files = defaultdict(list)
 
-        for source_path in self.project['source-paths']:
-            for root, dirs, files in os.walk(source_path):
+        for source_path in project['source-paths']:
+            full_source_path = os.path.join(project['project-root'], source_path)
+            for root, dirs, files in os.walk(full_source_path):
                 for filename in files:
                     abs_path = os.path.join(root, filename)
-                    rel_path = os.path.relpath(abs_path, source_path)
+                    rel_path = os.path.relpath(abs_path, full_source_path)
 
                     if fnmatch.fnmatch(filename, "*.sql"):
-                        indexed_files[source_path].append(rel_path)
+                        indexed_files[full_source_path].append(rel_path)
 
         return indexed_files
 
@@ -45,7 +47,7 @@ class CompileTask:
         table_or_view = 'table' if model_config['materialized'] else 'view'
 
         ctx = self.project.context()
-        schema = ctx['env']['schema']
+        schema = ctx['env'].get('schema', 'public')
 
         create_template = "create {table_or_view} {schema}.{identifier} as ( {query} );"
 
@@ -98,5 +100,12 @@ class CompileTask:
                     self.__write(f, create_stmt)
 
     def run(self):
-        src_index = self.__src_index()
-        self.__compile(src_index)
+        sources = self.__project_sources(self.project)
+
+        for obj in os.listdir(self.project['modules-path']):
+            full_obj = os.path.join(self.project['modules-path'], obj)
+            if os.path.isdir(full_obj):
+                project = dbt.project.read_project(os.path.join(full_obj, 'dbt_project.yml'))
+                sources.update(self.__project_sources(project))
+
+        self.__compile(sources)

--- a/dbt/task/deps.py
+++ b/dbt/task/deps.py
@@ -1,0 +1,25 @@
+import os
+import yaml
+import pprint
+import subprocess
+
+
+class DepsTask:
+    def __init__(self, args, project):
+        self.args = args
+        self.project = project
+
+    def __clone_or_update_repo(self, repo):
+        p = subprocess.Popen(
+            ['git', 'clone', repo],
+            cwd=self.project['modules-path'])
+
+        out = p.communicate()
+
+    def run(self):
+        pprint.pprint(self.project['modules-path'])
+        if not os.path.exists(os.path.dirname(self.project['modules-path'])):
+            os.makedirs(self.project['modules-path'])
+
+        for repo in self.project['repositories']:
+            self.__clone_or_update_repo(repo)

--- a/dbt/task/run.py
+++ b/dbt/task/run.py
@@ -201,4 +201,3 @@ class RunTask:
         self.__create_schema()
         self.__load_models()
         self.__execute_models()
-

--- a/sample.dbt_project.yml
+++ b/sample.dbt_project.yml
@@ -20,3 +20,5 @@ models:
       enabled: true       # enable this specific model (false to disable)
       materialized: true  # create a table instead of a view
 
+repositories:
+  - "git@github.com:analyst-collective/analytics"


### PR DESCRIPTION
Allow project dependencies to be specified by providing pointers to dependent [git] repositories, and wire those dependencies into the compilation step.

Lots of open questions about how this user experience should work, so this version emphasizes simplicity with the goal of getting some user feedback.

Tests: 
 - [x] deps are pulled correctly from a clean slate
 - [x] deps are updated when they already exist
 - [x] compilation includes dependent sources
 - [x] common dependencies of one or more modules are handled
 - [x] circular dependencies converge quickly, don't blow up
 - [x] dependencies that aren't dbt projects are rejected