### PR TITLE
Sort and Dist Keys

### DIFF
--- a/dbt/task/compile.py
+++ b/dbt/task/compile.py
@@ -5,7 +5,7 @@ import jinja2
 import yaml
 from collections import defaultdict
 
-CREATE_TABLE_TEMPLATE = """
+CREATE_STATEMENT_TEMPLATE = """
 create {table_or_view} {schema}.{identifier} {distkey_str} {sortkey_str}
     as (
         {query}
@@ -74,7 +74,7 @@ class CompileTask:
             "sortkey_str": sort_key
         }
 
-        return CREATE_TABLE_TEMPLATE.format(**opts)
+        return CREATE_STATEMENT_TEMPLATE.format(**opts)
 
     def __get_model_identifiers(self, model_filepath):
         model_group = os.path.dirname(model_filepath)

--- a/dbt/task/compile.py
+++ b/dbt/task/compile.py
@@ -56,7 +56,7 @@ class CompileTask:
         sort_key = ""
         if 'sort' in model_config:
             sort_config = model_config['sort']
-            if type(sort_config) == 'str':
+            if type(sort_config) == str:
                 sort_config = [sort_config]
             sort_key_list = ", ".join('"{}"'.format(key) for key in sort_config)
             sort_key = "sortkey ({})".format(sort_key_list)

--- a/dbt/task/compile.py
+++ b/dbt/task/compile.py
@@ -71,8 +71,14 @@ class CompileTask:
         ctx = self.project.context()
         schema = ctx['env'].get('schema', 'public')
 
-        dist_qualifier = self.__dist_qualifier(model_config) if 'dist' in model_config else ""
-        sort_qualifier = self.__sort_qualifier(model_config) if 'sort' in model_config else ""
+        dist_qualifier = ""
+        sort_qualifier = ""
+
+        if table_or_view == 'table':
+            if 'dist' in model_config:
+                dist_qualifier = self.__dist_qualifier(model_config)
+            if 'sort' in model_config:
+                sort_qualifier = self.__sort_qualifier(model_config)
 
         opts = {
             "table_or_view": table_or_view,

--- a/dbt/task/compile.py
+++ b/dbt/task/compile.py
@@ -52,7 +52,12 @@ class CompileTask:
         return "sortkey ({})".format(', '.join(formatted_sort_keys))
 
     def __dist_qualifier(self, model_config):
-        return 'distkey ("{}")'.format(model_config['dist'])
+        dist_key = model_config['dist']
+
+        if type(dist_key) != str:
+            raise RuntimeError("The provided distkey '{}' is not valid!".format(dist_key))
+
+        return 'distkey ("{}")'.format(dist_key)
 
     def __wrap_in_create(self, path, query, model_config):
         filename = os.path.basename(path)

--- a/dbt/task/run.py
+++ b/dbt/task/run.py
@@ -71,6 +71,9 @@ class Linker(object):
         new_nodes = set()
 
         def extract_deps(stmt):
+            if stmt is None:
+                return
+
             token = stmt.token_first()
             while token is not None:
                 excluded_types = [sqlparse.sql.Function] # don't dive into window functions

--- a/dbt/task/run.py
+++ b/dbt/task/run.py
@@ -71,9 +71,6 @@ class Linker(object):
         new_nodes = set()
 
         def extract_deps(stmt):
-            if stmt is None:
-                return
-
             token = stmt.token_first()
             while token is not None:
                 excluded_types = [sqlparse.sql.Function] # don't dive into window functions

--- a/sample.dbt_project.yml
+++ b/sample.dbt_project.yml
@@ -20,5 +20,11 @@ models:
       enabled: true       # enable this specific model (false to disable)
       materialized: true  # create a table instead of a view
 
+      # You can choose sort keys, a dist key, or both to improve query efficiency. By default, materialized
+      # tables are created with no sort or dist keys.
+      #
+      sort: ['@timestamp', '@userid'] # optionally set one or more sort keys on the materialized table
+      dist: '@userid'                 # optionally set a distribution key on the materialized table
+
 repositories:
   - "git@github.com:analyst-collective/analytics"

--- a/sample.dbt_project.yml
+++ b/sample.dbt_project.yml
@@ -26,5 +26,9 @@ models:
       sort: ['@timestamp', '@userid'] # optionally set one or more sort keys on the materialized table
       dist: '@userid'                 # optionally set a distribution key on the materialized table
 
+    pardot_visitoractivity:
+      materialized: false
+      sort: ['@timestamp']  # this has no effect, as sort and dist keys only apply to materialized tables
+
 repositories:
   - "git@github.com:analyst-collective/analytics"


### PR DESCRIPTION
This branch adds sort and dist keys to materialized tables.

In your `dbt_project.yml` file:

```yml
models:
  zuora:
    enabled: true
    materialized: true

    zuora_account:
      sort: ['id', 'account_number'] # optional
      dist: id                       # optional

    zuora_subscription:
      materialized: false   # create a view
      sort: id              # has no effect

    zuora_rate_plan:
      sort: id              # can also be specified as 'id' or  [id] or ['id']
```