### PR TITLE
Feature/namespacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,20 @@ user:                         # you can have multiple profiles for different pro
 `dbt clean` to clear compiled files
 
 
+#### troubleshooting
+
+If you see an error that looks like
+> Error: pg_config executable not found
+while installing dbt, make sure that you have development versions of postgres installed
+
+```bash
+# linux
+sudo apt-get install libpq-dev python-dev
+
+# osx
+brew install postgresql
+```
+
 #### contributing
 
 From the root directory of this repository, run:

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ A data build tool
 
 # configure dbt file paths (relative to dbt_project.yml)
 
+# the package config is _required_. If other packages import this package, 
+# the name given below is used to reference this package
+package:
+  name: 'package_name'
+  version: '1.0'
+
 source-paths: ["models"]   # paths with source code to compile
 target-path: "target"      # path for compiled code
 clean-targets: ["target"]  # directories removed by the clean task

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ user:                         # you can have multiple profiles for different pro
 
 If you see an error that looks like
 > Error: pg_config executable not found
+
 while installing dbt, make sure that you have development versions of postgres installed
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A data build tool
 
 #### configuration
 
-  Create a `dbt_project.yml` file in the root of your [models](https://github.com/analyst-collective/models) directory. Also create a  `profiles.yml` file in the `~/.dbt` directory. If this directory doesn't exist, you should create it. The
+  Create a `dbt_project.yml` file in the root of your [analytics](https://github.com/analyst-collective/analytics) directory. Also create a  `profiles.yml` file in the `~/.dbt` directory. If this directory doesn't exist, you should create it. The
   `dbt_project.yml` file should be checked in to your models repository, so be sure that it does *not* contain any database
   credentials! Make sure that all of your private information is stored in the `~/.dbt/profiles.yml` configuration file.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A data build tool
   `dbt_project.yml` file should be checked in to your models repository, so be sure that it does *not* contain any database
   credentials! Make sure that all of your private information is stored in the `~/.dbt/profiles.yml` configuration file.
 
-##### dbt_project.yml
+##### example dbt_project.yml
 ```yml
 
 # configure dbt file paths (relative to dbt_project.yml)
@@ -39,7 +39,7 @@ models:
       materialized: true  # create a table instead of a view
 ```
 
-##### ~/.dbt/profiles.yml
+##### example ~/.dbt/profiles.yml
 ```yml
 user:                         # you can have multiple profiles for different projects
   outputs:

--- a/dbt/compilation.py
+++ b/dbt/compilation.py
@@ -1,0 +1,25 @@
+
+import networkx as nx
+
+class Linker(object):
+    def __init__(self):
+        self.graph = nx.DiGraph()
+
+    def as_dependency_list(self):
+        return nx.topological_sort(self.graph, reverse=True)
+
+    def dependency(self, node1, node2):
+        "indicate that node1 depends on node2"
+        self.graph.add_node(node1)
+        self.graph.add_node(node2)
+        self.graph.add_edge(node1, node2)
+
+    def add_node(self, node):
+        self.graph.add_node(node)
+
+    def write_graph(self, outfile):
+        nx.write_yaml(self.graph, outfile)
+
+    def read_graph(self, infile):
+        self.graph = nx.read_yaml(infile)
+

--- a/dbt/project.py
+++ b/dbt/project.py
@@ -5,7 +5,6 @@ import copy
 import sys
 
 default_project_cfg = {
-    'package': {'name': None, 'version': None},
     'source-paths': ['models'],
     'test-paths': ['test'],
     'target-path': 'target',
@@ -82,9 +81,10 @@ class Project:
         target_cfg = self.run_environment()
         target_name = self.cfg['run-target']
 
-        package = self.cfg['package']
+        package_name = self.cfg.get('name', None)
+        package_version = self.cfg.get('version', None)
 
-        if package['name'] is None or package['version'] is None:
+        if package_name is None or package_version is None:
             raise DbtProjectError("Project name and version is not provided", self)
 
         required_keys = ['host', 'user', 'pass', 'schema', 'type', 'dbname', 'port']

--- a/dbt/project.py
+++ b/dbt/project.py
@@ -5,6 +5,7 @@ import copy
 import sys
 
 default_project_cfg = {
+    'package': {'name': None, 'version': None},
     'source-paths': ['models'],
     'test-paths': ['test'],
     'target-path': 'target',
@@ -69,7 +70,7 @@ class Project:
         target_cfg = self.run_environment()
         filtered_target = copy.deepcopy(target_cfg)
         filtered_target.pop('pass', None)
-        return {'env': target_cfg}
+        return {'env': filtered_target}
 
     def with_profiles(self, profiles=[]):
         return Project(
@@ -80,6 +81,11 @@ class Project:
     def validate(self):
         target_cfg = self.run_environment()
         target_name = self.cfg['run-target']
+
+        package = self.cfg['package']
+
+        if package['name'] is None or package['version'] is None:
+            raise DbtProjectError("Project name and version is not provided", self)
 
         required_keys = ['host', 'user', 'pass', 'schema', 'type', 'dbname', 'port']
         for key in required_keys:
@@ -106,10 +112,5 @@ def read_project(filename):
         profiles = read_profiles()
         proj = Project(project_cfg, profiles, default_active_profiles)
 
-        try:
-            proj.validate()
-        except DbtProjectError as e:
-          print(e.message)
-          print(e.project)
-
+        proj.validate()
         return proj

--- a/dbt/task/compile.py
+++ b/dbt/task/compile.py
@@ -27,6 +27,14 @@ class Linker(object):
         self.graph.add_node(node2)
         self.graph.add_edge(node1, node2)
 
+    def add_node(self, node):
+        self.graph.add_node(node)
+
+    def write_graph(self, outfile):
+        nx.write_yaml(self.graph, outfile)
+
+    def read_graph(self, infile):
+        self.graph = nx.read_yaml(infile)
 
 class CompileTask:
     def __init__(self, args, project):
@@ -148,6 +156,9 @@ class CompileTask:
     def __ref(self, ctx, source_model):
         schema = ctx['env']['schema']
 
+        # if this node doesn't have any deps, still make sure it's a part of the graph
+        self.linker.add_node(source_model)
+
         def do_ref(other_model_name):
             other_model = self.__find_model_by_name(other_model_name)
             self.linker.dependency(source_model, other_model)
@@ -189,3 +200,6 @@ class CompileTask:
                 sources.update(self.__project_sources(project))
 
         self.__compile(sources)
+
+        graph_path = os.path.join(self.project['target-path'], 'graph.yml')
+        self.linker.write_graph(graph_path)

--- a/dbt/task/compile.py
+++ b/dbt/task/compile.py
@@ -184,7 +184,7 @@ class CompileTask:
                 template = jinja.get_template(f)
 
                 context = self.project.context()
-                source_model = (model_group, model_name)
+                source_model = (project['name'], model_group, model_name)
                 context['ref'] = self.__ref(linker, context, source_model, project_models)
 
                 rendered = template.render(context)

--- a/dbt/task/compile.py
+++ b/dbt/task/compile.py
@@ -6,7 +6,7 @@ import yaml
 import dbt.project
 from collections import defaultdict
 
-from ..compilation import Linker
+from dbt.compilation import Linker
 
 CREATE_STATEMENT_TEMPLATE = """
 create {table_or_view} {schema}.{identifier} {dist_qualifier} {sort_qualifier} as (

--- a/dbt/task/compile.py
+++ b/dbt/task/compile.py
@@ -145,15 +145,15 @@ class CompileTask:
                 return model
         raise RuntimeError("Can't find a model named '{}' -- does it exist?".format(name))
 
-    def __load(self, ctx, source_model):
+    def __ref(self, ctx, source_model):
         schema = ctx['env']['schema']
 
-        def do_load(other_model_name):
+        def do_ref(other_model_name):
             other_model = self.__find_model_by_name(other_model_name)
             self.linker.dependency(source_model, other_model)
             return '"{}"."{}"'.format(schema, other_model_name)
 
-        return do_load
+        return do_ref
 
     def __compile(self, src_index):
         for src_path, files in src_index.items():
@@ -170,7 +170,7 @@ class CompileTask:
 
                 context = self.project.context()
                 source_model = (model_group, model_name)
-                context['load'] = self.__load(context, source_model)
+                context['ref'] = self.__ref(context, source_model)
 
                 rendered = template.render(context)
 

--- a/dbt/task/compile.py
+++ b/dbt/task/compile.py
@@ -4,6 +4,9 @@ import fnmatch
 import jinja2
 import yaml
 from collections import defaultdict
+from functools import partial
+
+NAMESPACE_DELIMITER = "."
 
 class CompileTask:
     def __init__(self, args, project):
@@ -37,17 +40,16 @@ class CompileTask:
         with open(target_path, 'w') as f:
             f.write(payload)
 
-    def __wrap_in_create(self, path, query, model_config):
-        filename = os.path.basename(path)
-        identifier, ext = os.path.splitext(filename)
-
+    def __wrap_in_create(self, namespace, model_name, query, model_config):
         # default to view if not provided in config!
         table_or_view = 'table' if model_config['materialized'] else 'view'
 
         ctx = self.project.context()
         schema = ctx['env']['schema']
 
-        create_template = "create {table_or_view} {schema}.{identifier} as ( {query} );"
+        create_template = 'create {table_or_view} "{schema}"."{identifier}" as ( {query} );'
+
+        identifier = NAMESPACE_DELIMITER.join(namespace + [model_name])
 
         opts = {
             "table_or_view": table_or_view,
@@ -59,40 +61,52 @@ class CompileTask:
         return create_template.format(**opts)
 
     def __get_model_identifiers(self, model_filepath):
-        model_group = os.path.dirname(model_filepath)
+        namespace = os.path.dirname(model_filepath).split("/")
         model_name, _ = os.path.splitext(os.path.basename(model_filepath))
-        return model_group, model_name
+        return namespace, model_name
 
-    def __get_model_config(self, model_group, model_name):
+    def __get_model_config(self, namespace, model_name):
         """merges model, model group, and base configs together. Model config
-        takes precedence, then model_group, then base config"""
+        takes precedence, then namespace, then base config"""
 
         config = self.project['model-defaults'].copy()
 
-        model_configs = self.project['models']
-        model_group_config = model_configs.get(model_group, {})
-        model_config = model_group_config.get(model_name, {})
+        namespace_config = self.project['models']
 
-        config.update(model_group_config)
+        for item in namespace:
+            namespace_config = namespace_config.get(item, {})
+            config.update(namespace_config)
+
+        model_config = namespace_config.get(model_name, {})
         config.update(model_config)
 
         return config
+
+    def __include(self, calling_model, *args):
+        print 'called from', calling_model, 'args:', args
+
+    def __context(self, calling_model):
+        ctx = self.project.context()
+        ctx['resolve'] = partial(self.__include, calling_model)
+        return ctx
 
     def __compile(self, src_index):
         for src_path, files in src_index.items():
             jinja = jinja2.Environment(loader=jinja2.FileSystemLoader(searchpath=src_path))
             for f in files:
 
-                model_group, model_name = self.__get_model_identifiers(f)
-                model_config = self.__get_model_config(model_group, model_name)
+                namespace, model_name = self.__get_model_identifiers(f)
+                model_config = self.__get_model_config(namespace, model_name)
 
                 if not model_config.get('enabled'):
                     continue
 
-                template = jinja.get_template(f)
-                rendered = template.render(self.project.context())
+                qualified_name = namespace + [model_name]
 
-                create_stmt = self.__wrap_in_create(f, rendered, model_config)
+                template = jinja.get_template(f)
+                rendered = template.render(self.__context(qualified_name))
+
+                create_stmt = self.__wrap_in_create(namespace, model_name, rendered, model_config)
 
                 if create_stmt:
                     self.__write(f, create_stmt)

--- a/dbt/task/run.py
+++ b/dbt/task/run.py
@@ -72,7 +72,7 @@ class RunTask:
                 namespace = os.path.dirname(f)
                 model_name, _ = os.path.splitext(os.path.basename(f))
 
-                model = (namespace, model_name)
+                model = (self.project['name'], namespace, model_name)
                 self.model_sql_map[model] = fh.read()
 
     def __query_for_existing(self, cursor, schema):
@@ -105,7 +105,7 @@ class RunTask:
                     return
 
                 for model in dependency_list:
-                    namespace, model_name = model
+                    package_name, namespace, model_name = model
                     if model_name in existing:
                         print("dropping {} '{}.{}'".format(existing[model_name], target.schema, model_name))
                         self.__drop(cursor, target.schema, model_name, existing[model_name])

--- a/dbt/task/run.py
+++ b/dbt/task/run.py
@@ -3,7 +3,7 @@ import psycopg2
 import os, sys
 import fnmatch
 
-from ..compilation import Linker
+from dbt.compilation import Linker
 
 class RedshiftTarget:
     def __init__(self, cfg):

--- a/dbt/task/run.py
+++ b/dbt/task/run.py
@@ -2,10 +2,6 @@ import pprint
 import psycopg2
 import os
 import fnmatch
-import re
-
-import sqlparse
-import networkx as nx
 
 class RedshiftTarget:
     def __init__(self, cfg):
@@ -30,104 +26,10 @@ class RedshiftTarget:
         return psycopg2.connect(self.__get_spec())
 
 
-class Relation(object):
-    def __init__(self, schema, name):
-        self.schema = schema
-        self.name = name
-
-    def valid(self):
-        return None not in (self.schema, self.name)
-
-    @property
-    def val(self):
-        return "{}.{}".format(self.schema, self.name)
-
-    def __repr__(self):
-        return self.val
-
-    def __str__(self):
-        return self.val
-
-class Linker(object):
-    def __init__(self, graph=None):
-        if graph is None:
-            self.graph = nx.DiGraph()
-        else:
-            self.graph = graph
-
-        self.node_sql_map = {}
-
-    def extract_name_and_deps(self, stmt):
-        table_def = stmt.token_next_by_instance(0, sqlparse.sql.Identifier)
-        schema, tbl_or_view =  table_def.get_parent_name(), table_def.get_real_name()
-        if schema is None or tbl_or_view is None:
-            raise RuntimeError('schema or view not defined?')
-
-        definition = table_def.token_next_by_instance(0, sqlparse.sql.Parenthesis)
-
-        definition_node = Relation(schema, tbl_or_view)
-
-        local_defs = set()
-        new_nodes = set()
-
-        def extract_deps(stmt):
-            token = stmt.token_first()
-            while token is not None:
-                excluded_types = [sqlparse.sql.Function] # don't dive into window functions
-                if type(token) not in excluded_types and token.is_group():
-                    # this is a thing that has a name -- note that!
-                    local_defs.add(token.get_name())
-                    # recurse into the group
-                    extract_deps(token)
-
-                if type(token) == sqlparse.sql.Identifier:
-                    new_node = Relation(token.get_parent_name(), token.get_real_name())
-
-                    if new_node.valid():
-                        new_nodes.add(new_node) # don't add edges yet!
-
-                index = stmt.token_index(token)
-                token = stmt.token_next(index)
-
-        extract_deps(definition)
-
-        # only add nodes which don't reference locally defined constructs
-        for new_node in new_nodes:
-            if new_node.schema not in local_defs:
-                self.graph.add_node(new_node.val)
-                self.graph.add_edge(definition_node.val, new_node.val)
-
-        return definition_node.val
-
-    def as_dependency_list(self):
-        order = nx.topological_sort(self.graph, reverse=True)
-        for node in order:
-            if node in self.node_sql_map: # TODO :
-                yield (node, self.node_sql_map[node])
-            else:
-                pass
-
-    def register(self, node, sql):
-        if node in self.node_sql_map:
-            raise RuntimeError("multiple declarations of node: {}".format(node))
-        self.node_sql_map[node] = sql
-
-    def link(self, sql):
-        sql = sql.strip()
-        for statement in sqlparse.parse(sql):
-            if statement.get_type().startswith('CREATE'):
-                node = self.extract_name_and_deps(statement)
-                self.register(node, sql)
-            else:
-                print("Ignoring {}".format(sql[0:100].replace('\n', ' ')))
-
-
 class RunTask:
     def __init__(self, args, project):
         self.args = args
         self.project = project
-
-        self.linker = Linker()
 
     def __compiled_files(self):
         compiled_files = []
@@ -192,7 +94,6 @@ class RunTask:
                         handle.commit()
 
                     print("creating {}".format(relation))
-                    #print("         {}...".format(re.sub( '\s+', ' ', sql[0:100] ).strip()))
                     cursor.execute(sql)
                     print("         {}".format(cursor.statusmessage))
                     handle.commit()

--- a/dbt/task/run.py
+++ b/dbt/task/run.py
@@ -2,7 +2,8 @@ import pprint
 import psycopg2
 import os
 import fnmatch
-from compile import Linker
+
+from ..compilation import Linker
 
 class RedshiftTarget:
     def __init__(self, cfg):

--- a/sample.dbt_project.yml
+++ b/sample.dbt_project.yml
@@ -1,37 +1,22 @@
-# This is an annotated sample project configuration for reference.
-# It attempts to show all possible configuration options.
+# configure dbt file paths (relative to dbt_project.yml)
 
-# Compile configuration
-source-paths: ["model"]   # paths with source code to compile
-target-path: "target"     # path for compiled code
-clean-targets: ["target"] # directories removed by the clean task
+source-paths: ["models"]   # paths with source code to compile
+target-path: "target"      # path for compiled code
+clean-targets: ["target"]  # directories removed by the clean task
+test-paths: ["test"]       # where to store test results
+
+# default paramaters that apply to _all_ models (unless overridden below)
 
 model-defaults:
-  enabled: true        # enable all models by default
-  materialized: false  # If true, create tables. If false, create views
+  enabled: true           # enable all models by default
+  materialized: false     # If true, create tables. If false, create views
+
+# custom configurations for each model. Unspecified models will use the model-defaults information above.
 
 models:
-  pardot:
-    enabled: true           # explicity enable all models in this group
-    pardot_visitoractivity: # override configs for a particular model
-      enabled: true         # explicitly enable this model. Could optionally be "false" instead
-      materialized: true    # create a table instead of a view (overriding the base config)
+  pardot:                 # assuming pardot is listed in the models/ directory
+    enabled: true         # enable all pardot models except where overriden (same as default)
+    pardot_emails:        # override the configs for the pardot_emails model
+      enabled: true       # enable this specific model (false to disable)
+      materialized: true  # create a table instead of a view
 
-# Run configuration
-# output environments
-outputs:
-  my-redshift: # uniquely named
-    type: redshift # only type supported
-    host: localhost # any IP or fqdn
-    port: 5439
-    user: my_user
-    # best practice: specify outputs in your user profile
-    # located in ~/.dbt/profiles.yml to ensure credentials
-    # don't get checked in alongside your model code
-    pass: password
-    dbname: dev
-    schema: my_model_schema
-run-target: my-redshift
-
-# Test configuration
-test-paths: ["test"]

--- a/sample.dbt_project.yml
+++ b/sample.dbt_project.yml
@@ -12,9 +12,9 @@ model-defaults:
 
 models:
   pardot:
-    enabled: false          # disable all pardot models except where overriden
+    enabled: true           # explicity enable all models in this group
     pardot_visitoractivity: # override configs for a particular model
-      enabled: true         # enable this model
+      enabled: true         # explicitly enable this model. Could optionally be "false" instead
       materialized: true    # create a table instead of a view (overriding the base config)
 
 # Run configuration

--- a/sample.dbt_project.yml
+++ b/sample.dbt_project.yml
@@ -1,5 +1,11 @@
 # configure dbt file paths (relative to dbt_project.yml)
 
+# the package config is _required_. If other packages import this package, 
+# the name given below is used to reference this package
+package:
+  name: 'package_name'
+  version: '1.0'
+
 source-paths: ["models"]   # paths with source code to compile
 target-path: "target"      # path for compiled code
 clean-targets: ["target"]  # directories removed by the clean task

--- a/sample.profiles.yml
+++ b/sample.profiles.yml
@@ -1,0 +1,16 @@
+# Put this file in ~/.dbt/profiles.yml
+#
+# This is an annotated sample project configuration for reference.
+# It attempts to show all possible configuration options.
+#
+user:                         # you can have multiple profiles for different projects
+  outputs:
+    my-redshift:              # uniquely named, you can have different targets in a profile
+      type: redshift          # only type supported
+      host: localhost         # any IP or fqdn
+      port: 5439
+      user: my_user
+      pass: password
+      dbname: dev
+      schema: my_model_schema # the schema to create models in (eg. analyst_collective)
+  run-target: my-redshift     # which target to run sql against


### PR DESCRIPTION
Previously, models which referenced other models did so by explicitly pointing to them eg:

```sql
select * from {{env.schema}}.pardot_emails
```

This made sense at the time, but it requires us to parse SQL (tricky but doable), and worse: it requires users to explicitly point exactly to the name of the table. With this branch, users can specify a model name in a function call which resolves to the full path to that model, eg:

```sql
select * from {{ ref("pardot_emails") }} -- resolves to "analyst_collective"."pardot_emails"
```

- [x] remove sql parsing
- [x] generate graph via calls to `load(...)` in sql
- [x] play nice with deps
- [x] store graph in `target` dir after compilation
- [x] load graph in call to `dbt run`
- [x] edit model files accordingly

see also: https://github.com/analyst-collective/analytics/pull/36