### PR TITLE
Feature/testing v2

### DIFF
--- a/dbt/compilation.py
+++ b/dbt/compilation.py
@@ -155,7 +155,7 @@ class Compiler(object):
         model_name, _ = os.path.splitext(os.path.basename(model_filepath))
         return model_group, model_name
 
-    def __get_model_config(self, model_group, model_name):
+    def get_model_config(self, model_group, model_name):
         """merges model, model group, and base configs together. Model config
         takes precedence, then model_group, then base config"""
 
@@ -218,7 +218,7 @@ class Compiler(object):
 
                 model_group, model_name = self.__get_model_identifiers(f)
                 model_name = self.create_template.model_name(model_name)
-                model_config = self.__get_model_config(model_group, model_name)
+                model_config = self.get_model_config(model_group, model_name)
 
                 if not model_config.get('enabled'):
                     continue

--- a/dbt/main.py
+++ b/dbt/main.py
@@ -41,7 +41,7 @@ def main(args=None):
 
     sub = subs.add_parser('test', parents=[base_subparser])
     sub.add_argument('--skip-test-creates', action='store_true', help="Don't create temporary views to validate model SQL")
-    sub.add_argument('--validate', action='store_true', help='Name of the new project')
+    sub.add_argument('--validate', action='store_true', help='Run constraint validations from schema.yml files')
     sub.set_defaults(cls=test_task.TestTask, which='test')
 
     parsed = p.parse_args(args)

--- a/dbt/main.py
+++ b/dbt/main.py
@@ -40,6 +40,7 @@ def main(args=None):
     sub.set_defaults(cls=run_task.RunTask, which='run')
 
     sub = subs.add_parser('test', parents=[base_subparser])
+    sub.add_argument('--validate', action='store_true', help='Name of the new project')
     sub.set_defaults(cls=test_task.TestTask, which='test')
 
     parsed = p.parse_args(args)

--- a/dbt/main.py
+++ b/dbt/main.py
@@ -40,6 +40,7 @@ def main(args=None):
     sub.set_defaults(cls=run_task.RunTask, which='run')
 
     sub = subs.add_parser('test', parents=[base_subparser])
+    sub.add_argument('--skip-test-creates', action='store_true', help="Don't create temporary views to validate model SQL")
     sub.add_argument('--validate', action='store_true', help='Name of the new project')
     sub.set_defaults(cls=test_task.TestTask, which='test')
 

--- a/dbt/runner.py
+++ b/dbt/runner.py
@@ -146,7 +146,7 @@ class Runner:
         try:
             self.__create_schema()
             for model in self.__execute_models(linker):
-                yield model
+                yield model, True
         except psycopg2.OperationalError as e:
             print("ERROR: Could not connect to the target database. Try `dbt debug` for more information")
             print(e.message)

--- a/dbt/schema_tester.py
+++ b/dbt/schema_tester.py
@@ -1,0 +1,159 @@
+import os
+import yaml
+
+from dbt.runner import RedshiftTarget
+
+QUERY_VALIDATE_NOT_NULL = """
+with validation as (
+  select "{field}" as f
+  from "{schema}"."{table}"
+)
+select count(*) from validation where f is null
+"""
+
+QUERY_VALIDATE_UNIQUE = """
+with validation as (
+  select "{field}" as f
+  from "{schema}"."{table}"
+)
+select count(*) from (
+  select f from validation group by f having count(*) > 1
+)
+"""
+
+QUERY_VALIDATE_REFERENTIAL_INTEGRITY = """
+with parent as (
+  select "{parent_field}" as id
+  from "{schema}"."{parent_table}"
+), child as (
+  select "{child_field}" as id
+  from "{schema}"."{child_table}"
+)
+select count(*) from child
+where id not in (select id from parent) and id is not null
+"""
+
+class SchemaTester(object):
+    def __init__(self, project):
+        self.project = project
+
+    def project_schemas(self):
+        schemas = {}
+
+        for source_path in self.project['source-paths']:
+            full_source_path = os.path.join(self.project['project-root'], source_path)
+            for root, dirs, files in os.walk(full_source_path):
+                for filename in files:
+                    if filename == "schema.yml":
+                        filepath = os.path.join(root, filename)
+                        with open(filepath) as fh:
+                            project_cfg = yaml.safe_load(fh)
+                            schemas.update(project_cfg)
+
+        return schemas
+
+    def get_query_params(self, table, field):
+        target_cfg = self.project.run_environment()
+        schema = target_cfg['schema']
+        return {
+            "schema": schema,
+            "table": table,
+            "field": field
+        }
+
+    def make_query(self, query, params):
+        return query.format(**params)
+
+    def get_target(self):
+        target_cfg = self.project.run_environment()
+        if target_cfg['type'] == 'redshift':
+            return RedshiftTarget(target_cfg)
+        else:
+            raise NotImplementedError("Unknown target type '{}'".format(target_cfg['type']))
+
+    def execute_query(self, model, sql):
+        target = self.get_target()
+
+        with target.get_handle() as handle:
+            with handle.cursor() as cursor:
+                try:
+                    cursor.execute(sql)
+                except Exception as e:
+                    e.model = model
+                    raise e
+
+                result = cursor.fetchone()
+                if len(result) != 1:
+                    print("SQL: {}".format(sql))
+                    print("RESULT:".format(result))
+                    raise RuntimeError("Unexpected validation result. Expected 1 record, got {}".format(len(result)))
+                else:
+                    return result[0]
+
+    def validate_not_null(self, model, constraint_data):
+        for field in constraint_data:
+            params = self.get_query_params(model, field)
+            sql = self.make_query(QUERY_VALIDATE_NOT_NULL, params)
+            print ('VALIDATE NOT NULL "{}"."{}"'.format(model, field))
+            num_rows = self.execute_query(model, sql)
+            if num_rows == 0:
+                print("  OK")
+            else:
+                print("  FAILED ({})".format(num_rows))
+
+    def validate_unique(self, model, constraint_data):
+        for field in constraint_data:
+            params = self.get_query_params(model, field)
+            sql = self.make_query(QUERY_VALIDATE_UNIQUE, params)
+            print ('VALIDATE UNIQUE "{}"."{}"'.format(model, field))
+            num_rows = self.execute_query(model, sql)
+            if num_rows == 0:
+                print("  OK")
+            else:
+                print("  FAILED ({})".format(num_rows))
+
+    def validate_relationships(self, model, constraint_data):
+        for reference in constraint_data:
+            target_cfg = self.project.run_environment()
+            params = {
+                "schema": target_cfg['schema'],
+                "parent_table": model,
+                "parent_field": reference['from'],
+                "child_table": reference['to'],
+                "child_field": reference['field']
+            }
+            sql = self.make_query(QUERY_VALIDATE_REFERENTIAL_INTEGRITY, params)
+            print ('VALIDATE REFERENTIAL INTEGRITY "{}"."{}" to "{}"."{}"'.format(model, reference['from'], reference['to'], reference['field']))
+            num_rows = self.execute_query(model, sql)
+            if num_rows == 0:
+                print("  OK")
+            else:
+                print("  FAILED ({})".format(num_rows))
+
+    def validate_schema_constraint(self, model, constraint_type, constraint_data):
+        constraint_map = {
+            'not_null': self.validate_not_null,
+            'unique': self.validate_unique,
+            'relationships': self.validate_relationships
+        }
+
+        if constraint_type in constraint_map:
+            validator = constraint_map[constraint_type]
+            validator(model, constraint_data)
+        else:
+            raise RuntimeError("Invalid constraint '{}' specified for '{}' in schema.yml".format(constraint_type, model))
+
+    def validate_schema(self, schemas):
+        "generate queries for each schema constraints"
+
+        for model, schema_info in schemas.items():
+            constraints = schema_info['constraints']
+            for constraint_type, constraint_data in constraints.items():
+                try:
+                    self.validate_schema_constraint(model, constraint_type, constraint_data)
+                except RuntimeError as e:
+                    print("ERRROR: {}".format(e.message))
+
+    def test(self):
+        schemas = self.project_schemas()
+        self.validate_schema(schemas)

--- a/dbt/task/run.py
+++ b/dbt/task/run.py
@@ -15,5 +15,5 @@ class RunTask:
         target_path = self.get_target()
 
         runner = Runner(self.project, target_path, BaseCreateTemplate.label)
-        for model in runner.run():
+        for (model, passed) in runner.run():
             pass

--- a/dbt/task/test.py
+++ b/dbt/task/test.py
@@ -40,7 +40,7 @@ class TestTask:
 
         return executed_models
 
-    def run(self):
+    def run_test_creates(self):
         self.compile()
 
         try:
@@ -56,10 +56,23 @@ class TestTask:
 
         num_passed = len(results)
         print("{num_passed}/{num_passed} tests passed!".format(num_passed=num_passed))
+        print("")
+
+    def run_validations(self):
+        print("Validating schemas")
+        schema_tester = SchemaTester(self.project)
+        schema_tester.test()
+
+
+    def run(self):
+        if self.args.skip_test_creates:
+            print("Skipping test creates (--skip-test-creates provided)")
+        else:
+            self.run_test_creates()
 
         if self.args.validate:
-            print("")
-            print("Validating schemas")
-            schema_tester = SchemaTester(self.project)
-            schema_tester.test()
+            self.run_validations()
+        else:
+            print("Skipping validations (--validate not provided)")
 
+        print("Done!")

--- a/dbt/task/test.py
+++ b/dbt/task/test.py
@@ -35,15 +35,12 @@ class TestTask:
         executed_models = runner.run()
 
         # clean up
+        print("Cleaning up.")
         runner.drop_models(executed_models)
 
         return executed_models
 
     def run(self):
-        schema_tester = SchemaTester(self.project)
-        schema_tester.test()
-
-        return
         self.compile()
 
         try:
@@ -59,4 +56,10 @@ class TestTask:
 
         num_passed = len(results)
         print("{num_passed}/{num_passed} tests passed!".format(num_passed=num_passed))
+
+        if self.args.validate:
+            print("")
+            print("Validating schemas")
+            schema_tester = SchemaTester(self.project)
+            schema_tester.test()
 

--- a/dbt/task/test.py
+++ b/dbt/task/test.py
@@ -29,6 +29,8 @@ class TestTask:
         compiler.initialize()
         compiler.compile()
 
+        return compiler
+
     def execute(self):
         target_path = self.get_target()
         runner = Runner(self.project, target_path, TestCreateTemplate.label)
@@ -41,7 +43,6 @@ class TestTask:
         return executed_models
 
     def run_test_creates(self):
-        self.compile()
 
         try:
             results = self.execute()
@@ -58,20 +59,22 @@ class TestTask:
         print("{num_passed}/{num_passed} tests passed!".format(num_passed=num_passed))
         print("")
 
-    def run_validations(self):
+    def run_validations(self, compiler):
         print("Validating schemas")
         schema_tester = SchemaTester(self.project)
-        schema_tester.test()
+        schema_tester.test(compiler)
 
 
     def run(self):
+        compiler = self.compile()
+
         if self.args.skip_test_creates:
             print("Skipping test creates (--skip-test-creates provided)")
         else:
             self.run_test_creates()
 
         if self.args.validate:
-            self.run_validations()
+            self.run_validations(compiler)
         else:
             print("Skipping validations (--validate not provided)")
 

--- a/dbt/task/test.py
+++ b/dbt/task/test.py
@@ -33,11 +33,14 @@ class TestTask:
 
     def run_and_catch_errors(self, func, onFinally=None):
         executed_models = []
+        passed = 0
 
         errored = False
         try:
-            for model in func():
+            for (model, test_passed) in func():
                 executed_models.append(model)
+                if test_passed:
+                    passed += 1
         except psycopg2.ProgrammingError as e:
             errored = True
             print("")
@@ -54,7 +57,7 @@ class TestTask:
         print("")
 
         num_passed = len(executed_models)
-        print("{num_passed}/{num_passed} tests passed!".format(num_passed=num_passed))
+        print("{passed}/{num_executed} tests passed!".format(passed=passed, num_executed=num_passed))
         print("")
 
     def run_test_creates(self):

--- a/dbt/task/test.py
+++ b/dbt/task/test.py
@@ -1,12 +1,22 @@
 
 import os, sys
 import psycopg2
+import yaml
 
 from dbt.compilation import Compiler
 from dbt.templates import TestCreateTemplate
 from dbt.runner import Runner
+from dbt.schema_tester import SchemaTester
 
 class TestTask:
+    """
+    Testing:
+        1) Create tmp views w/ 0 rows to ensure all tables, schemas, and SQL statements are valid
+        2) Read schema files and validate that constraints are satisfied
+           a) not null
+           b) uniquenss
+           c) referential integrity
+    """
     def __init__(self, args, project):
         self.args = args
         self.project = project
@@ -30,6 +40,10 @@ class TestTask:
         return executed_models
 
     def run(self):
+        schema_tester = SchemaTester(self.project)
+        schema_tester.test()
+
+        return
         self.compile()
 
         try:


### PR DESCRIPTION
Testing V2 -- This makes it possible to test that model schemas conform to expectations

Here are two example schema definitions for `pardot_visitoractivity` and `pardot_visitoractivity_events_meta`.

File: `models/pardot/schema.yml`
```yml
pardot_visitoractivity:
  constraints:
    not_null:
      - prospect_id
    unique: []
    relationships:
      - {from: type, to: pardot_visitoractivity_events_meta, field: type}
      - {from: type, to: pardot_visitoractivity_types_meta, field: type}

pardot_visitoractivity_events_meta:
  constraints:
    not_null:
      - type_name
      - event_name
    unique:
      - event_name
    relationships:
      - {from: type, to: pardot_visitoractivity, field: type}
```

There are three possible validations:
 - uniqueness 
 - not-null
 - referential integrity

For more information: https://github.com/analyst-collective/dbt/issues/38

### Usage
`dbt test` : run V1 tests (temp create views w/ 0 rows -- checks for sql validity)
`dbt test --validate` : run V2 tests (query for rows which do not conform to the specified schema)
`dbt test --validate --skip-test-creates` : run V2 tests, but skip V1 tests 

Note that testing also follows the enabled/disabled rules in `dbt_config.yml`. For instance, if `pardot` models are disabled, then the pardot tests will not be run!