### PR TITLE
ignore common temporary editor files during compilation

### DIFF
--- a/dbt/compilation.py
+++ b/dbt/compilation.py
@@ -64,7 +64,7 @@ class Compiler(object):
                     abs_path = os.path.join(root, filename)
                     rel_path = os.path.relpath(abs_path, full_source_path)
 
-                    if fnmatch.fnmatch(filename, "*.sql"):
+                    if fnmatch.fnmatch(filename, "[!.#~]*.sql"):
                         indexed_files[full_source_path].append((project, rel_path))
 
         return indexed_files


### PR DESCRIPTION
I ran into an error because a temporary file named `.#model.sql` in the same directory as my model was deleted mid-compilation, resulting in this trace:

```
Traceback (most recent call last):
  File "/Users/cmerrick/.virtualenvs/dbt/bin/dbt", line 6, in <module>
    exec(compile(open(__file__).read(), __file__, 'exec'))
  File "/Users/cmerrick/dbt/scripts/dbt", line 8, in <module>
    dbt.main.main(sys.argv[1:])
  File "/Users/cmerrick/dbt/dbt/main.py", line 77, in main
    parsed.cls(args=parsed, project=proj).run()
  File "/Users/cmerrick/dbt/dbt/task/compile.py", line 14, in run
    created_models = compiler.compile()
  File "/Users/cmerrick/dbt/dbt/compilation.py", line 254, in compile
    linker = self.__do_compile(sources, project_models)
  File "/Users/cmerrick/dbt/dbt/compilation.py", line 227, in __do_compile
    template = jinja.get_template(f)
  File "/Users/cmerrick/.virtualenvs/dbt/lib/python2.7/site-packages/Jinja2-2.8-py2.7.egg/jinja2/environment.py", line 812, in get_template
    return self._load_template(name, self.make_globals(globals))
  File "/Users/cmerrick/.virtualenvs/dbt/lib/python2.7/site-packages/Jinja2-2.8-py2.7.egg/jinja2/environment.py", line 774, in _load_template
    cache_key = self.loader.get_source(self, name)[1]
  File "/Users/cmerrick/.virtualenvs/dbt/lib/python2.7/site-packages/Jinja2-2.8-py2.7.egg/jinja2/loaders.py", line 187, in get_source
    raise TemplateNotFound(template)
jinja2.exceptions.TemplateNotFound: base/.#clients.sql
```

