### PR TITLE
Feature/materialize incremental

### DIFF
--- a/dbt/model.py
+++ b/dbt/model.py
@@ -22,7 +22,7 @@ class DBTSource(object):
             return fh.read().strip()
 
     def get_config_keys(self):
-        return ['enabled', 'materialized', 'dist', 'sort', 'incremental_field']
+        return ['enabled', 'materialized', 'dist', 'sort', 'sql_field']
 
     def compile(self):
         raise RuntimeError("Not implemented!")
@@ -123,12 +123,12 @@ class Model(DBTSource):
 
         if materialization in ('table', 'view'):
             identifier = self.tmp_name()
-            incremental_field = None
+            sql_field = None
         else:
             identifier = self.name
-            if 'incremental_field' not in model_config:
-                raise RuntimeError("incremental_field not specified in model materialized as incremental: {}".format(self))
-            incremental_field = model_config['incremental_field']
+            if 'sql_field' not in model_config:
+                raise RuntimeError("sql_field not specified in model materialized as incremental: {}".format(self))
+            sql_field = model_config['sql_field']
 
         opts = {
             "materialization": materialization,
@@ -137,7 +137,7 @@ class Model(DBTSource):
             "query": rendered_query,
             "dist_qualifier": dist_qualifier,
             "sort_qualifier": sort_qualifier,
-            "incremental_field": incremental_field
+            "sql_field": sql_field
         }
 
         return create_template.wrap(opts)

--- a/dbt/model.py
+++ b/dbt/model.py
@@ -84,6 +84,8 @@ class Model(DBTSource):
         super(Model, self).__init__(project, model_dir, rel_filepath)
 
     def sort_qualifier(self, model_config):
+        if 'sort' not in model_config:
+            return ''
         sort_keys = model_config['sort']
         if type(sort_keys) == str:
             sort_keys = [sort_keys]
@@ -93,6 +95,9 @@ class Model(DBTSource):
         return "sortkey ({})".format(', '.join(formatted_sort_keys))
 
     def dist_qualifier(self, model_config):
+        if 'dist' not in model_config:
+            return ''
+
         dist_key = model_config['dist']
 
         if type(dist_key) != str:
@@ -117,9 +122,9 @@ class Model(DBTSource):
         ctx = project.context()
         schema = ctx['env'].get('schema', 'public')
 
-        is_table = materialization == 'table'
-        dist_qualifier = self.dist_qualifier(model_config) if 'dist' in model_config and is_table else ''
-        sort_qualifier = self.sort_qualifier(model_config) if 'sort' in model_config and is_table else ''
+        # these are empty strings if configs aren't provided
+        dist_qualifier = self.dist_qualifier(model_config)
+        sort_qualifier = self.sort_qualifier(model_config)
 
         if materialization in ('table', 'view'):
             identifier = self.tmp_name()

--- a/dbt/model.py
+++ b/dbt/model.py
@@ -22,7 +22,7 @@ class DBTSource(object):
             return fh.read().strip()
 
     def get_config_keys(self):
-        return ['enabled', 'materialized', 'dist', 'sort']
+        return ['enabled', 'materialized', 'dist', 'sort', 'incremental_field']
 
     def compile(self):
         raise RuntimeError("Not implemented!")
@@ -108,22 +108,36 @@ class Model(DBTSource):
 
     def compile(self, rendered_query, project, create_template):
         model_config = self.get_config(project)
-        table_or_view = 'table' if model_config['materialized'] else 'view'
+
+        valid_materializations = ['view', 'table', 'incremental']
+        materialization = model_config['materialized']
+        if materialization not in valid_materializations:
+            raise RuntimeError("Invalid materialize option given: '{}'. Must be one of {}".format(materialization, valid_materializations))
 
         ctx = project.context()
         schema = ctx['env'].get('schema', 'public')
 
-        is_table = table_or_view == 'table'
+        is_table = materialization == 'table'
         dist_qualifier = self.dist_qualifier(model_config) if 'dist' in model_config and is_table else ''
         sort_qualifier = self.sort_qualifier(model_config) if 'sort' in model_config and is_table else ''
 
+        if materialization in ('table', 'view'):
+            identifier = self.tmp_name()
+            incremental_field = None
+        else:
+            identifier = self.name
+            if 'incremental_field' not in model_config:
+                raise RuntimeError("incremental_field not specified in model materialized as incremental: {}".format(self))
+            incremental_field = model_config['incremental_field']
+
         opts = {
-            "table_or_view": table_or_view,
+            "materialization": materialization,
             "schema": schema,
-            "identifier": self.tmp_name(),
+            "identifier": identifier,
             "query": rendered_query,
             "dist_qualifier": dist_qualifier,
-            "sort_qualifier": sort_qualifier
+            "sort_qualifier": sort_qualifier,
+            "incremental_field": incremental_field
         }
 
         return create_template.wrap(opts)

--- a/dbt/runner.py
+++ b/dbt/runner.py
@@ -150,11 +150,10 @@ class Runner:
         model = data['model']
         tmp_drop_type = data['tmp_drop_type']
         final_drop_type = data['final_drop_type']
-        exists = data['exists']
 
         error = None
         try:
-            self.execute_model(target, model, tmp_drop_type, final_drop_type, exists)
+            self.execute_model(target, model, tmp_drop_type, final_drop_type)
         except (RuntimeError, psycopg2.ProgrammingError) as e:
             error = "Error executing {filepath}\n{error}".format(filepath=model.filepath, error=str(e).strip())
 
@@ -178,7 +177,7 @@ class Runner:
         self.execute_and_handle_permissions(target, rename_query, model, model.name)
         self.logger.info("renamed model %s.%s --> %s.%s", target.schema, model.tmp_name(), target.schema, model.name)
 
-    def execute_model(self, target, model, tmp_drop_type, final_drop_type, exists):
+    def execute_model(self, target, model, tmp_drop_type, final_drop_type):
         self.logger.info("executing model %s", model)
 
         if tmp_drop_type is not None:
@@ -209,14 +208,13 @@ class Runner:
             model = self.get_model_by_fqn(models, fqn)
 
             model_config = model.get_config(model.project)
-            exists = model.name in existing
             if model_config.get('materialized') == 'incremental':
                 tmp_drop_type = None
                 final_drop_type = None
             else:
                 tmp_drop_type = existing.get(model.tmp_name(), None) 
                 final_drop_type = existing.get(model.name, None)
-            return {"model" : model, "target": target, "tmp_drop_type": tmp_drop_type, 'final_drop_type': final_drop_type, "exists": exists}
+            return {"model" : model, "target": target, "tmp_drop_type": tmp_drop_type, 'final_drop_type': final_drop_type}
 
         # we can only pass one arg to the self.execute_model method below. Pass a dict w/ all the data we need
         model_dependency_list = [[wrap_fqn(target, models, existing, fqn) for fqn in node_list] for node_list in dependency_list]

--- a/dbt/seeder.py
+++ b/dbt/seeder.py
@@ -77,7 +77,7 @@ class Seeder:
                 self.insert_into_table(cursor, schema, table_name, virtual_table)
             except psycopg2.ProgrammingError as e:
                 print('Encountered an error while inserting into table "{}"."{}"'.format(schema, table_name))
-                print('Check for formatting errors in {}'.format(csv_path))
+                print('Check for formatting errors in {}'.format(csv.filepath))
                 print('Try --drop-existing to delete and recreate the table instead')
                 print(str(e))
 

--- a/dbt/templates.py
+++ b/dbt/templates.py
@@ -16,13 +16,13 @@ class BaseCreateTemplate(object):
 
     insert into "{schema}"."{identifier}" (
         with dbt_inc_sbq as (
-            select max("{incremental_field}") as dbt_max from "{schema}"."{identifier}"
+            select max({sql_field}) as __dbt_max from "{schema}"."{identifier}"
         ), dbt_raw_sbq as (
             {query}
         )
         select dbt_raw_sbq.* from dbt_raw_sbq
-        join dbt_inc_sbq on dbt_raw_sbq."{incremental_field}" > dbt_inc_sbq.dbt_max or dbt_inc_sbq.dbt_max is null
-        order by dbt_raw_sbq."{incremental_field}"
+        join dbt_inc_sbq on {sql_field} > dbt_inc_sbq.__dbt_max or dbt_inc_sbq.__dbt_max is null
+        order by {sql_field}
     );
     """
 

--- a/dbt/templates.py
+++ b/dbt/templates.py
@@ -6,7 +6,7 @@ class BaseCreateTemplate(object):
     );"""
 
     incremental_template = """
-    create temporary table "{identifier}__dbt_incremental_tmp" as (
+    create temporary table "{identifier}__dbt_incremental_tmp" {dist_qualifier} {sort_qualifier} as (
         SELECT * FROM (
             {query}
         ) as tmp LIMIT 0

--- a/dbt/templates.py
+++ b/dbt/templates.py
@@ -6,6 +6,14 @@ class BaseCreateTemplate(object):
     );"""
 
     incremental_template = """
+    create temporary table "{identifier}__dbt_incremental_tmp" as (
+        SELECT * FROM (
+            {query}
+        ) as tmp LIMIT 0
+    );
+
+    create table if not exists "{schema}"."{identifier}" (like "{identifier}__dbt_incremental_tmp");
+
     insert into "{schema}"."{identifier}" (
         with dbt_inc_sbq as (
             select max("{incremental_field}") as dbt_max from "{schema}"."{identifier}"


### PR DESCRIPTION
Materialize models as `incremental`. Each execution of `dbt run` will
  1. create the model if it doesn't exist
  2. insert new records (via the model definition) into the model

To take advantage of this feature, update your `dbt_project.yml` file:

```yml
models:
  'JamJar':
    events:
      materialized: incremental                 # set this field to 'incremental'
      sql_field: cast(collector_tstamp as date) # specify a field name or arbitrary sql
      ...
```

Incremental models can also built with sort and dist keys (specified in the config)

cc @jthandy 