### PR TITLE
in-model configs, show config options in prologue

### DIFF
--- a/dbt/compilation.py
+++ b/dbt/compilation.py
@@ -140,6 +140,12 @@ class Compiler(object):
             f.write(payload)
 
 
+    def __model_config(self, model):
+        def do_config(**kwargs):
+            model.update_in_model_config(kwargs)
+            model.add_to_prologue("Config specified in model: {}".format(kwargs))
+        return do_config
+
     def __ref(self, linker, ctx, model, all_models):
         schema = ctx['env']['schema']
 
@@ -191,6 +197,7 @@ class Compiler(object):
 
         context = self.project.context()
         context['ref'] = self.__ref(linker, context, model, models)
+        context['config'] = self.__model_config(model)
 
         rendered = template.render(context)
         return rendered


### PR DESCRIPTION
With this branch, configurations can be specified directly inside of models. The configs work exactly the same as configs inside of the `dbt_project.yml` file.

An in-model-config looks like this:
```sql
{{ config(materialized="incremental", sql_where="id > (select max(id) from {{this}})") }}
-- or you can use python dict syntax:
{{ config({"materialized:" "incremental", "sql_where" : "id > (select max(id) from {{this}})"}) }}
-- you can only call config() once in a model, so don't do both!

select * from public.users
```

The config options are injected into the existing configs (more on this below) and the `config(...)` function call is replaced with a SQL comment containing the injected config options, eg:

```sql
-- Config specified in model: {'materialized': 'incremental', 'sql_where': 'id > (select max(id) from {{this}})'}

select * from public.users
```

If the model is in your package, then config resolution works in the following order (later configs overwrite previous configs):

1. model-defaults (dbt_project.yml)
2. models (dbt_project.yml)
3. in-model configs (your_model.sql)



If the model is in a package that your package lists as a dependency:

1. DEPENDENCY model-defaults (dep/dbt_project.yml)
2. DEPENDENCY models (dep/dbt_project.yml)
3. DEPENDENCY in-model configs (dep/models/your_model.sql)
4. YOUR models (dbt_project.yml)

Note that in the latter scenario, the model-defaults in your dbt_project.yml file is ignored! 
