### PR TITLE
Refactor/simplify models

### DIFF
--- a/dbt/compilation.py
+++ b/dbt/compilation.py
@@ -135,7 +135,7 @@ class Compiler(object):
             f.write(payload)
 
 
-    def __model_config(self, model):
+    def __model_config(self, model, linker):
         def do_config(*args, **kwargs):
             if len(args) == 1 and len(kwargs) == 0:
                 opts = args[0]
@@ -152,6 +152,8 @@ class Compiler(object):
             if already_called:
                 raise RuntimeError("config() called more than once in {}".format(model))
 
+            # update linker graph w/ options
+            linker.add_node(tuple(model.fqn), opts)
             model.update_in_model_config(opts)
             model.add_to_prologue("Config specified in model: {}".format(opts))
             return ""
@@ -208,7 +210,7 @@ class Compiler(object):
 
         context = self.project.context()
         context['ref'] = self.__ref(linker, context, model, models)
-        context['config'] = self.__model_config(model)
+        context['config'] = self.__model_config(model, linker)
 
         rendered = template.render(context)
         return rendered

--- a/dbt/compilation.py
+++ b/dbt/compilation.py
@@ -6,83 +6,8 @@ from collections import defaultdict
 import dbt.project
 from dbt.source import Source
 from dbt.utils import find_model_by_name, dependency_projects
+from dbt.linker import Linker
 import sqlparse
-
-import networkx as nx
-
-class Linker(object):
-    def __init__(self):
-        self.graph = nx.DiGraph()
-        self.cte_map = defaultdict(set)
-
-    def nodes(self):
-        return self.graph.nodes()
-
-    def get_node(self, node):
-        return self.graph.node[node]
-
-    def as_topological_ordering(self, limit_to=None):
-        try:
-            return nx.topological_sort(self.graph, nbunch=limit_to)
-        except KeyError as e:
-            raise RuntimeError("Couldn't find model '{}' -- does it exist or is it diabled?".format(e))
-
-    def as_dependency_list(self, limit_to=None):
-        """returns a list of list of nodes, eg. [[0,1], [2], [4,5,6]]. Each element contains nodes whose
-        dependenices are subsumed by the union of all lists before it. In this way, all nodes in list `i`
-        can be run simultaneously assuming that all lists before list `i` have been completed"""
-
-        if limit_to is None:
-            graph_nodes = set(self.graph.nodes())
-        else:
-            graph_nodes = set()
-            for node in limit_to:
-                graph_nodes.add(node)
-                if node in self.graph:
-                    graph_nodes.update(nx.descendants(self.graph, node))
-                else:
-                    raise RuntimeError("Couldn't find model '{}' -- does it exist or is it diabled?".format(node))
-
-        depth_nodes = defaultdict(list)
-
-        for node in graph_nodes:
-            num_ancestors = len(nx.ancestors(self.graph, node))
-            depth_nodes[num_ancestors].append(node)
-
-        dependency_list = []
-        for depth in sorted(depth_nodes.keys()):
-            dependency_list.append(depth_nodes[depth])
-
-        return dependency_list
-
-    def inject_cte(self, source, cte_model):
-        self.cte_map[source].add(cte_model)
-
-    def is_child_of(self, nodes, target_node):
-        "returns True if node is a child of a node in nodes. Otherwise, False"
-        node_span = set()
-        for node in nodes:
-            node_span.add(node)
-            for child in nx.descendants(self.graph, node):
-                node_span.add(child)
-
-        return target_node in node_span
-
-    def dependency(self, node1, node2):
-        "indicate that node1 depends on node2"
-        self.graph.add_node(node1)
-        self.graph.add_node(node2)
-        self.graph.add_edge(node2, node1)
-
-    def add_node(self, node, data=None):
-        node_data = {} if data is None else data
-        self.graph.add_node(node, node_data)
-
-    def write_graph(self, outfile):
-        nx.write_yaml(self.graph, outfile)
-
-    def read_graph(self, infile):
-        self.graph = nx.read_yaml(infile)
 
 class Compiler(object):
     def __init__(self, project, create_template_class):
@@ -105,9 +30,9 @@ class Compiler(object):
 
         paths = own_project.get('source-paths', [])
         if self.create_template.label == 'build':
-            return Source(this_project, own_project=own_project).get_models(paths)
+            return Source(this_project, own_project=own_project).get_models(paths, self.create_template)
         elif self.create_template.label == 'test':
-            return Source(this_project, own_project=own_project).get_test_models(paths)
+            return Source(this_project, own_project=own_project).get_test_models(paths, self.create_template)
         else:
             raise RuntimeError("unexpected create template type: '{}'".format(self.create_template.label))
 
@@ -147,13 +72,6 @@ class Compiler(object):
             if type(opts) != dict:
                 raise RuntimeError("Invalid model config given inline in {}".format(model))
 
-            already_called = len(model.in_model_config) > 0
-
-            if already_called:
-                raise RuntimeError("config() called more than once in {}".format(model))
-
-            # update linker graph w/ options
-            linker.add_node(tuple(model.fqn), opts)
             model.update_in_model_config(opts)
             model.add_to_prologue("Config specified in model: {}".format(opts))
             return ""
@@ -163,7 +81,7 @@ class Compiler(object):
         schema = ctx['env']['schema']
 
         source_model = tuple(model.fqn)
-        linker.add_node(source_model, {"materialized": model.materialization})
+        linker.add_node(source_model)
 
         def do_ref(*args):
             if len(args) == 1:
@@ -276,6 +194,8 @@ class Compiler(object):
             all_models.extend(self.model_sources(this_project=self.project, own_project=project))
 
         models = [model for model in all_models if model.is_enabled]
+        for model in models:
+            model.create_template = self.create_template
 
         self.validate_models_unique(models)
 
@@ -290,11 +210,15 @@ class Compiler(object):
             injected_stmt = self.add_cte_to_rendered_query(model_linker, model, compiled_models)
             wrapped_stmt = model.compile(injected_stmt, self.project, self.create_template)
 
-            build_path = model.build_path(self.create_template)
+            build_path = model.build_path()
 
             if wrapped_stmt and not model.is_ephemeral:
                 written_models += 1
                 self.__write(build_path, wrapped_stmt)
+
+        for model in models:
+            serialized = model.serialize()
+            model_linker.update_node_data(tuple(model.fqn), serialized)
 
         self.__write_graph_file(model_linker)
 

--- a/dbt/linker.py
+++ b/dbt/linker.py
@@ -1,0 +1,80 @@
+
+import networkx as nx
+from collections import defaultdict
+
+class Linker(object):
+    def __init__(self):
+        self.graph = nx.DiGraph()
+        self.cte_map = defaultdict(set)
+
+    def nodes(self):
+        return self.graph.nodes()
+
+    def get_node(self, node):
+        return self.graph.node[node]
+
+    def as_topological_ordering(self, limit_to=None):
+        try:
+            return nx.topological_sort(self.graph, nbunch=limit_to)
+        except KeyError as e:
+            raise RuntimeError("Couldn't find model '{}' -- does it exist or is it diabled?".format(e))
+
+    def as_dependency_list(self, limit_to=None):
+        """returns a list of list of nodes, eg. [[0,1], [2], [4,5,6]]. Each element contains nodes whose
+        dependenices are subsumed by the union of all lists before it. In this way, all nodes in list `i`
+        can be run simultaneously assuming that all lists before list `i` have been completed"""
+
+        if limit_to is None:
+            graph_nodes = set(self.graph.nodes())
+        else:
+            graph_nodes = set()
+            for node in limit_to:
+                graph_nodes.add(node)
+                if node in self.graph:
+                    graph_nodes.update(nx.descendants(self.graph, node))
+                else:
+                    raise RuntimeError("Couldn't find model '{}' -- does it exist or is it diabled?".format(node))
+
+        depth_nodes = defaultdict(list)
+
+        for node in graph_nodes:
+            num_ancestors = len(nx.ancestors(self.graph, node))
+            depth_nodes[num_ancestors].append(node)
+
+        dependency_list = []
+        for depth in sorted(depth_nodes.keys()):
+            dependency_list.append(depth_nodes[depth])
+
+        return dependency_list
+
+    def inject_cte(self, source, cte_model):
+        self.cte_map[source].add(cte_model)
+
+    def is_child_of(self, nodes, target_node):
+        "returns True if node is a child of a node in nodes. Otherwise, False"
+        node_span = set()
+        for node in nodes:
+            node_span.add(node)
+            for child in nx.descendants(self.graph, node):
+                node_span.add(child)
+
+        return target_node in node_span
+
+    def dependency(self, node1, node2):
+        "indicate that node1 depends on node2"
+        self.graph.add_node(node1)
+        self.graph.add_node(node2)
+        self.graph.add_edge(node2, node1)
+
+    def add_node(self, node):
+        self.graph.add_node(node)
+
+    def update_node_data(self, node, data):
+        self.graph.add_node(node, data)
+
+    def write_graph(self, outfile):
+        nx.write_yaml(self.graph, outfile)
+
+    def read_graph(self, infile):
+        self.graph = nx.read_yaml(infile)
+

--- a/dbt/model.py
+++ b/dbt/model.py
@@ -4,23 +4,67 @@ import yaml
 import jinja2
 from dbt.templates import TestCreateTemplate
 
-class DBTSource(object):
+class SourceConfig(object):
     Materializations = ['view', 'table', 'incremental', 'ephemeral']
     ConfigKeys = ['enabled', 'materialized', 'dist', 'sort', 'sql_where']
+
+    def __init__(self, active_project, own_project, fqn):
+        self.active_project = active_project
+        self.own_project = own_project
+        self.fqn = fqn
+
+        self.in_model_config   = {} # the config options defined within the model
+
+    def _merge(self, *configs):
+        merged_config = {}
+        for config in configs:
+            merged_config.update(config)
+        return merged_config
+
+    # this is re-evaluated every time `config` is called.
+    # we can cache it, but that complicates thing. TODO : see how this fares performance-wise
+    @property
+    def config(self):
+        own_config = self.load_config_from_own_project()
+        active_config = self.load_config_from_active_project()
+        return self._merge(own_config, self.in_model_config, active_config)
+
+    def update_in_model_config(self, config):
+        self.in_model_config.update(config)
+
+    def get_project_config(self, project, skip_default=False):
+        config = {} if skip_default else project['model-defaults'].copy()
+
+        model_configs = project['models']
+
+        fqn = self.fqn[:]
+        for level in fqn:
+            level_config = model_configs.get(level, {})
+            relevant_configs = {key: level_config[key] for key in level_config if key in self.ConfigKeys}
+            config.update(relevant_configs)
+
+        return config
+
+    def load_config_from_own_project(self):
+        return self.get_project_config(self.own_project, skip_default=False)
+
+    def load_config_from_active_project(self):
+        return self.get_project_config(self.active_project, skip_default=True)
+
+class DBTSource(object):
 
     def __init__(self, project, top_dir, rel_filepath, own_project):
         self.project = project
         self.own_project = own_project
+
         self.top_dir = top_dir
         self.rel_filepath = rel_filepath
         self.filepath = os.path.join(top_dir, rel_filepath)
         self.filedir = os.path.dirname(self.filepath)
         self.name = self.fqn[-1]
         self.own_project_name = self.fqn[0]
-        self.in_model_config = {}
 
-        self.config = self.load_config_from_own_project()
-        self.config.update(self.load_config_from_active_project())
+        self.source_config = SourceConfig(project, own_project, self.fqn)
 
     @property
     def root_dir(self):
@@ -28,44 +72,29 @@ class DBTSource(object):
 
     def compile(self):
         raise RuntimeError("Not implemented!")
+    
+    def serialize(self):
+        serialized = {
+            "build_path": self.build_path(),
+            "source_path": self.filepath,
+            "name": self.name,
+            "tmp_name": self.tmp_name()
+        }
+
+        serialized.update(self.config)
+        return serialized
 
     @property
     def contents(self):
         with open(self.filepath) as fh:
             return fh.read().strip()
 
+    @property
+    def config(self):
+        return self.source_config.config
+
     def update_in_model_config(self, config):
-        self.in_model_config.update(config)
-
-        self.config = self.load_config_from_own_project()
-        self.config.update(self.in_model_config)
-        self.config.update(self.load_config_from_active_project())
-
-    def __load_config_from_project(self, the_project, skip_default=False):
-        if skip_default:
-            config = {}
-        else:
-            config = the_project['model-defaults'].copy()
-        model_configs = the_project['models']
-        fqn = self.original_fqn[:]
-        while len(fqn) > 0:
-            model_group = fqn.pop(0)
-            if model_group in model_configs:
-                model_configs = model_configs[model_group]
-                relevant_configs = {key: model_configs[key] for key in self.ConfigKeys if key in model_configs}
-                config.update(relevant_configs)
-            else:
-                break
-        return config
-
-    def load_config_from_own_project(self):
-        return self.__load_config_from_project(self.own_project, skip_default=False)
-
-    def load_config_from_active_project(self):
-        # overwrite dep config w/ primary config if different
-        if self.project['name'] != self.own_project['name']:
-            return self.__load_config_from_project(self.project, skip_default=True)
-        return {}
+        self.source_config.update_in_model_config(config)
 
     @property
     def materialization(self):
@@ -89,7 +118,7 @@ class DBTSource(object):
 
     @property
     def is_enabled(self):
-        return self.config.get('enabled')
+        return self.config['enabled']
 
 
     @property
@@ -117,8 +146,9 @@ class DBTSource(object):
 
 
 class Model(DBTSource):
-    def __init__(self, project, model_dir, rel_filepath, own_project):
+    def __init__(self, project, model_dir, rel_filepath, own_project, create_template):
         self.prologue = []
+        self.create_template = create_template
         super(Model, self).__init__(project, model_dir, rel_filepath, own_project)
 
     def add_to_prologue(self, s):
@@ -150,17 +180,17 @@ class Model(DBTSource):
 
         return 'distkey ("{}")'.format(dist_key)
 
-    def build_path(self, create_template):
-        build_dir = create_template.label
-        filename = "{}.sql".format(create_template.model_name(self.name))
+    def build_path(self):
+        build_dir = self.create_template.label
+        filename = "{}.sql".format(self.create_template.model_name(self.name))
         path_parts = [build_dir] + self.fqn[:-1] + [filename]
         return os.path.join(*path_parts)
 
     def compile(self, rendered_query, project, create_template):
         model_config = self.config
 
-        if self.materialization not in DBTSource.Materializations:
-            raise RuntimeError("Invalid materialize option given: '{}'. Must be one of {}".format(self.materialization, DBTSource.Materializations))
+        if self.materialization not in SourceConfig.Materializations:
+            raise RuntimeError("Invalid materialize option given: '{}'. Must be one of {}".format(self.materialization, SourceConfig.Materializations))
 
         ctx = project.context().copy()
         schema = ctx['env'].get('schema', 'public')
@@ -206,9 +236,9 @@ class Analysis(Model):
     def __init__(self, project, target_dir, rel_filepath, own_project):
         return super(Analysis, self).__init__(project, target_dir, rel_filepath, own_project)
 
-    def build_path(self, create_template):
-        build_dir = '{}-analysis'.format(create_template.label)
-        filename = "{}.sql".format(create_template.model_name(self.name))
+    def build_path(self):
+        build_dir = 'build-analysis'
+        filename = "{}.sql".format(self.name)
         path_parts = [build_dir] + self.fqn[:-1] + [filename]
         return os.path.join(*path_parts)
 
@@ -216,11 +246,11 @@ class Analysis(Model):
         return "<Analysis {}: {}>".format(self.name, self.filepath)
 
 class TestModel(Model):
-    def __init__(self, project, target_dir, rel_filepath, own_project):
-        return super(TestModel, self).__init__(project, target_dir, rel_filepath, own_project)
+    def __init__(self, project, target_dir, rel_filepath, own_project, create_template):
+        return super(TestModel, self).__init__(project, target_dir, rel_filepath, own_project, create_template)
 
-    def build_path(self, create_template):
-        build_dir = create_template.label
+    def build_path(self):
+        build_dir = self.create_template.label
         filename = "{}.sql".format(self.name)
         path_parts = [build_dir] + self.fqn[:-1] + [filename]
         return os.path.join(*path_parts)
@@ -243,19 +273,19 @@ class TestModel(Model):
         return "<TestModel {}.{}: {}>".format(self.project['name'], self.name, self.filepath)
 
 
-class CompiledModel(DBTSource):
-    def __init__(self, project, target_dir, rel_filepath, own_project):
-        return super(CompiledModel, self).__init__(project, target_dir, rel_filepath, own_project)
-
-    @property
-    def fqn(self):
-        "fully-qualified name for compiled model. Includes all subdirs below 'target/build-*' path and the filename"
-        parts = self.filepath.split("/")
-        name, _ = os.path.splitext(parts[-1])
-        return parts[2:-1] + [name]
-
-    def __repr__(self):
-        return "<CompiledModel {}.{}: {}>".format(self.project['name'], self.name, self.filepath)
+#class CompiledModel(DBTSource):
+#    def __init__(self, project, target_dir, rel_filepath, own_project):
+#        return super(CompiledModel, self).__init__(project, target_dir, rel_filepath, own_project)
+#
+#    @property
+#    def fqn(self):
+#        "fully-qualified name for compiled model. Includes all subdirs below 'target/build-*' path and the filename"
+#        parts = self.filepath.split("/")
+#        name, _ = os.path.splitext(parts[-1])
+#        return parts[2:-1] + [name]
+#
+#    def __repr__(self):
+#        return "<CompiledModel {}.{}: {}>".format(self.project['name'], self.name, self.filepath)
 
 class Schema(DBTSource):
     def __init__(self, project, target_dir, rel_filepath, own_project):

--- a/dbt/runner.py
+++ b/dbt/runner.py
@@ -6,7 +6,8 @@ import os, sys
 import logging
 import time
 
-from dbt.compilation import Linker, Compiler
+from dbt.compilation import Compiler
+from dbt.linker import Linker
 from dbt.templates import BaseCreateTemplate
 from dbt.targets import RedshiftTarget
 from dbt.source import Source

--- a/dbt/runner.py
+++ b/dbt/runner.py
@@ -256,13 +256,15 @@ class Runner:
                 model_results.append(model_result)
                 print("{} of {} -- SKIP relation {}.{} because parent failed".format(len(model_results), num_models, target.schema, model_result.model.name))
 
-            for i, model in enumerate(models_to_execute):
+
+            for i, wrapped_model in enumerate(models_to_execute):
+                model = wrapped_model['model']
                 print_vars = {
                     "progress": 1 + i + len(model_results),
                     "total" : num_models,
                     "schema": target.schema,
-                    "model_name": model['model'].name,
-                    "model_type": model['model'].materialization,
+                    "model_name": model.name,
+                    "model_type": linker.get_node(tuple(model.fqn)).get('materialized', model.materialization),
                     "info": "START"
                 }
 
@@ -279,7 +281,7 @@ class Runner:
                     "total" : num_models,
                     "schema": target.schema,
                     "model_name": run_model_result.model.name,
-                    "model_type": run_model_result.model.materialization,
+                    "model_type": linker.get_node(tuple(model.fqn)).get('materialized', model.materialization),
                     "info": "ERROR creating" if run_model_result.errored else "OK created"
                 }
 

--- a/dbt/source.py
+++ b/dbt/source.py
@@ -1,7 +1,7 @@
 
 import os.path
 import fnmatch
-from dbt.model import Model, Analysis, CompiledModel, TestModel, Schema, Csv
+from dbt.model import Model, Analysis, TestModel, Schema, Csv
 
 class Source(object):
     def __init__(self, project, own_project=None):
@@ -27,14 +27,14 @@ class Source(object):
                         found.append((self.project, source_path, rel_path, self.own_project))
         return found
 
-    def get_models(self, model_dirs):
+    def get_models(self, model_dirs, create_template):
         pattern = "[!.#~]*.sql"
-        models = [Model(*model) for model in self.find(model_dirs, pattern)]
+        models = [Model(*model + (create_template,)) for model in self.find(model_dirs, pattern)]
         return models
 
-    def get_test_models(self, model_dirs):
+    def get_test_models(self, model_dirs, create_template):
         pattern = "[!.#~]*.sql"
-        models = [TestModel(*model) for model in self.find(model_dirs, pattern)]
+        models = [TestModel(*model + (create_template,)) for model in self.find(model_dirs, pattern)]
         return models
 
     def get_analyses(self, analysis_dirs):
@@ -42,21 +42,21 @@ class Source(object):
         models = [Analysis(*analysis) for analysis in self.find(analysis_dirs, pattern)]
         return models
 
-    def get_compiled(self, target_dir, compilation_type, project_mapping):
-        "Get compiled SQL files. compilation_type E {build, test}"
-        if compilation_type not in ['build', 'test']:
-            raise RuntimeError('Invalid compilation_type. Must be on of ["build", "test]. Got {}'.format(compilation_type))
-        pattern = "[!.#~]*.sql"
-        source_dir = os.path.join(target_dir, compilation_type)
-        compiled_models = []
-        for model in self.find([source_dir], pattern):
-            this_project, source_path, rel_path, _ = model
-            path_parts = rel_path.split("/")
-            project_name = path_parts[0] if len(path_parts) > 0 else self.project['name']
-            own_project = project_mapping[project_name]
-            compiled_model = CompiledModel(this_project, source_path, rel_path, own_project)
-            compiled_models.append(compiled_model)
-        return compiled_models
+    #def get_compiled(self, target_dir, compilation_type, project_mapping):
+    #    "Get compiled SQL files. compilation_type E {build, test}"
+    #    if compilation_type not in ['build', 'test']:
+    #        raise RuntimeError('Invalid compilation_type. Must be on of ["build", "test]. Got {}'.format(compilation_type))
+    #    pattern = "[!.#~]*.sql"
+    #    source_dir = os.path.join(target_dir, compilation_type)
+    #    compiled_models = []
+    #    for model in self.find([source_dir], pattern):
+    #        this_project, source_path, rel_path, _ = model
+    #        path_parts = rel_path.split("/")
+    #        project_name = path_parts[0] if len(path_parts) > 0 else self.project['name']
+    #        own_project = project_mapping[project_name]
+    #        compiled_model = CompiledModel(this_project, source_path, rel_path, own_project)
+    #        compiled_models.append(compiled_model)
+    #    return compiled_models
 
     def get_schemas(self, model_dirs):
         "Get schema.yml files"

--- a/dbt/source.py
+++ b/dbt/source.py
@@ -42,22 +42,6 @@ class Source(object):
         models = [Analysis(*analysis) for analysis in self.find(analysis_dirs, pattern)]
         return models
 
-    #def get_compiled(self, target_dir, compilation_type, project_mapping):
-    #    "Get compiled SQL files. compilation_type E {build, test}"
-    #    if compilation_type not in ['build', 'test']:
-    #        raise RuntimeError('Invalid compilation_type. Must be on of ["build", "test]. Got {}'.format(compilation_type))
-    #    pattern = "[!.#~]*.sql"
-    #    source_dir = os.path.join(target_dir, compilation_type)
-    #    compiled_models = []
-    #    for model in self.find([source_dir], pattern):
-    #        this_project, source_path, rel_path, _ = model
-    #        path_parts = rel_path.split("/")
-    #        project_name = path_parts[0] if len(path_parts) > 0 else self.project['name']
-    #        own_project = project_mapping[project_name]
-    #        compiled_model = CompiledModel(this_project, source_path, rel_path, own_project)
-    #        compiled_models.append(compiled_model)
-    #    return compiled_models
-
     def get_schemas(self, model_dirs):
         "Get schema.yml files"
         pattern = "[!.#~]*.yml"


### PR DESCRIPTION
Some code cleanup that will help with the next release.

We tried to treat CompiledModels like regular source Models which ended up not being a great abstraction. Primarily, we relied on reading the filesystem and re-generating configs both at compile-time and run-time. Now this data is serialized in the dbt graph yml file and the run-phase only needs to touch the filesystem to read compiled sql!

This ameliorates bugs that arise from slight difference between `compile` and `run` codepaths and supports in-model configs.