### PR TITLE
don't compile sort/dist keys into non-table models

### DIFF
--- a/dbt/model.py
+++ b/dbt/model.py
@@ -185,7 +185,7 @@ class Model(DBTSource):
         return "-- Compiled by DBT\n{}".format(blob)
 
     def sort_qualifier(self, model_config):
-        if 'sort' not in model_config:
+        if 'sort' not in model_config or self.is_view or self.is_ephemeral:
             return ''
         sort_keys = model_config['sort']
         if type(sort_keys) == str:
@@ -196,7 +196,7 @@ class Model(DBTSource):
         return "sortkey ({})".format(', '.join(formatted_sort_keys))
 
     def dist_qualifier(self, model_config):
-        if 'dist' not in model_config:
+        if 'dist' not in model_config or self.is_view or self.is_ephemeral:
             return ''
 
         dist_key = model_config['dist']

--- a/dbt/templates.py
+++ b/dbt/templates.py
@@ -5,6 +5,9 @@ create {materialization} "{schema}"."{identifier}" {dist_qualifier} {sort_qualif
     {query}
 );"""
 
+    # Distribution style, sort keys,BACKUP, and NULL properties are inherited by LIKE tables,
+    # but you cannot explicitly set them in the CREATE TABLE ... LIKE statement.
+    # via http://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_TABLE_NEW.html
     incremental_template = """
 create temporary table "{identifier}__dbt_incremental_tmp" {dist_qualifier} {sort_qualifier} as (
     select * from (


### PR DESCRIPTION
don't compile sort/dist keys into view or ephemeral models. Add comment which clarifies that sort/dist keys are indeed copied in `create table tbl (like other)` stmts