### PR TITLE
rollback transaction on error, clean up output

### DIFF
--- a/dbt/runner.py
+++ b/dbt/runner.py
@@ -229,7 +229,7 @@ class RunManager(object):
             status = "ERROR"
             self.logger.exception(error)
             if type(e) == psycopg2.InternalError and ABORTED_TRANSACTION_STRING == e.diag.message_primary:
-                return RunModelResult(model, error="An error occurred in a concurrently running model", status="SKIP")
+                return RunModelResult(model, error=ABORTED_TRANSACTION_STRING, status="SKIP")
         except Exception as e:
             error = "Unhandled error while executing {filepath}\n{error}".format(filepath=model['build_path'], error=str(e).strip())
             self.logger.exception(error)

--- a/dbt/targets.py
+++ b/dbt/targets.py
@@ -48,3 +48,7 @@ class RedshiftTarget:
         if self.handle is None:
             self.handle = psycopg2.connect(self.__get_spec())
         return self.handle
+
+    def rollback(self):
+        if self.handle is not None:
+            self.handle.rollback()


### PR DESCRIPTION
- don't use a transaction after if an error occurs in it (rollback first)
- catch "current transaction is aborted, commands ignored until end of transaction block" error
  - Print that an error occurred in a concurrently running model
  - Mark the model as "SKIP"
  - Skip all models dependent on the newly-failed model

This does pretty much the same thing as before, but the output is drastically cleaner. Figuring out what SQL broke was really hard when seemingly every model had it's own error! It looks like this:


```
Compiled 11 models, 8 tests, and 1 analyses
Concurrency: 8 threads (target='dev')
Running!

Running 11 models
1 of 11 START view model analytics.accounts .................................... [RUN]
2 of 11 START view model analytics.events ...................................... [RUN]
3 of 11 START table model analytics.people ..................................... [RUN]
1 of 11 ERROR creating view model analytics.accounts ........................... [ERROR]
Error executing target/build/some dependency/accounts.sql
The user 'dev' does not have sufficient permissions to create the model 'accounts'  in the schema 'analytics'.
Please adjust the permissions of the 'dev' user on the 'analytics' schema.
With a superuser account, execute the following commands, then re-run dbt.

grant usage, create on schema "analytics" to "dev";
grant select, insert, delete on all tables in schema "analytics" to "dev";
2 of 11 ERROR creating view model analytics.events ............................. [SKIP]
current transaction is aborted, commands ignored until end of transaction block
3 of 11 ERROR creating table model analytics.people ............................ [SKIP]
current transaction is aborted, commands ignored until end of transaction block
4 of 11 SKIP relation analytics.sessions_basic.................................. [SKIP]
5 of 11 SKIP relation analytics.page_pings...................................... [SKIP]
6 of 11 SKIP relation analytics.page_views...................................... [SKIP]
7 of 11 SKIP relation analytics.sessions_landing_page........................... [SKIP]
8 of 11 SKIP relation analytics.sessions_exit_page.............................. [SKIP]
9 of 11 SKIP relation analytics.people_accounts................................. [SKIP]
10 of 11 SKIP relation analytics.sessions_source................................ [SKIP]
11 of 11 SKIP relation analytics.sessions....................................... [SKIP]

Finished running 11 models

Done. PASS=0 ERROR=3 SKIP=8 TOTAL=11
```