### PR TITLE
Feature/simple hooks

### DIFF
--- a/dbt/compilation.py
+++ b/dbt/compilation.py
@@ -5,7 +5,7 @@ import jinja2
 from collections import defaultdict
 import dbt.project
 from dbt.source import Source
-from dbt.utils import find_model_by_fqn, find_model_by_name, dependency_projects
+from dbt.utils import find_model_by_fqn, find_model_by_name, dependency_projects, This
 from dbt.linker import Linker
 import sqlparse
 
@@ -102,7 +102,9 @@ class Compiler(object):
                 ref_fqn = ".".join(other_model_fqn)
                 raise RuntimeError("Model '{}' depends on model '{}' which is disabled in the project config".format(src_fqn, ref_fqn))
 
-            linker.dependency(source_model, other_model_fqn)
+            # this creates a trivial cycle -- should this be a compiler error?
+            if source_model != other_model_fqn:
+                linker.dependency(source_model, other_model_fqn)
 
             if other_model.is_ephemeral:
                 linker.inject_cte(model, other_model)
@@ -129,6 +131,13 @@ class Compiler(object):
         context = self.project.context()
         context['ref'] = self.__ref(linker, context, model, models)
         context['config'] = self.__model_config(model, linker)
+        context['this'] = This(context['env']['schema'], model.name)
+
+        hook_keys = ['pre-hook', 'post-hook']
+        for key in hook_keys:
+            hooks = model.config.get(key, [])
+            rendered_hooks = [jinja2.Environment().from_string(hook).render(context) for hook in hooks]
+            model.update_in_model_config({key: rendered_hooks})
 
         rendered = template.render(context)
         return rendered

--- a/dbt/linker.py
+++ b/dbt/linker.py
@@ -24,6 +24,7 @@ class Linker(object):
         except KeyError as e:
             raise RuntimeError("Couldn't find model '{}' -- does it exist or is it diabled?".format(e))
         except nx.exception.NetworkXUnfeasible as e:
+            import ipdb; ipdb.set_trace()
             cycle = " --> ".join([".".join(node) for node in  nx.algorithms.find_cycle(self.graph)[0]])
             raise RuntimeError("Can't compile -- cycle exists in model graph\n{}".format(cycle))
 

--- a/dbt/linker.py
+++ b/dbt/linker.py
@@ -24,7 +24,6 @@ class Linker(object):
         except KeyError as e:
             raise RuntimeError("Couldn't find model '{}' -- does it exist or is it diabled?".format(e))
         except nx.exception.NetworkXUnfeasible as e:
-            import ipdb; ipdb.set_trace()
             cycle = " --> ".join([".".join(node) for node in  nx.algorithms.find_cycle(self.graph)[0]])
             raise RuntimeError("Can't compile -- cycle exists in model graph\n{}".format(cycle))
 

--- a/dbt/model.py
+++ b/dbt/model.py
@@ -209,13 +209,6 @@ class Model(DBTSource):
     def add_to_prologue(self, s):
         self.prologue.append(s)
 
-    def get_model_hooks(self):
-        for pre_hook in self.config.get('pre-hook', []):
-            print pre_hook
-
-        for post_hook in self.config.get('post-hook', []):
-            print post_hook
-
     def get_prologue_string(self):
         blob = "\n".join("-- {}".format(s) for s in self.prologue)
         return "-- Compiled by DBT\n{}".format(blob)

--- a/dbt/templates.py
+++ b/dbt/templates.py
@@ -38,11 +38,31 @@ delete from "{schema}"."{identifier}" where  ({unique_key}) in (
 );
 """
 
+    extras_template = """
+{prologue}
+
+{pre_hooks};
+
+{sql}
+
+{post_hooks};
+"""
+
     label = "build"
 
     @classmethod
     def model_name(cls, base_name):
         return base_name
+
+    def add_extras(self, opts, sql):
+        extras = {
+            'prologue': opts['prologue'],
+            'pre_hooks': ';\n'.join(opts['pre-hooks']),
+            'sql': sql,
+            'post_hooks': ';\n'.join(opts['post-hooks']),
+        }
+
+        return self.extras_template.format(**extras)
 
     def wrap(self, opts):
         sql = ""
@@ -63,7 +83,8 @@ delete from "{schema}"."{identifier}" where  ({unique_key}) in (
         else:
             raise RuntimeError("Invalid materialization parameter ({})".format(opts['materialization']))
 
-        return "{}\n\n{}".format(opts['prologue'], sql)
+        return self.add_extras(opts, sql)
+
 
 class DryCreateTemplate(object):
     base_template = """

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -2,6 +2,14 @@
 import os
 import dbt.project
 
+class This(object):
+    def __init__(self, schema, table):
+        self.schema = schema
+        self.table = table
+
+    def __repr__(self):
+        return '"{}"."{}"'.format(self.schema, self.table)
+
 def find_model_by_name(models, name, package_namespace=None):
     found = []
     for model in models:


### PR DESCRIPTION
Implements the simple version of hooks. In your `dbt_project.yml` file:

```yaml
models:
  'Test DBT':
    pre-hook: "insert into {{ ref('audit') }} (model, timestamp, status) values ('{{this.table}}', getdate(), 'started')"
    post-hook:
       - "insert into {{ ref('audit') }} (model, timestamp, status) values ('{{this.table}}', getdate(), 'completed')"
       - "grant select on {{this}} to some_user"
```

There are a couple of new things here:
 - pre hooks run _before_ a model is executed
 - post hooks run _after_ a model is executed
 - hooks can be defined as either a string, or a list of strings
 - these hooks are a part of the transaction which materializes a model. If the transaction fails, the hooks will not be run.
 - the `{{ this }}` var has been extended such that you can use
  - `{{this}}` to interpolate `"schema"."table"`
  - `{{this.schema}}` to interpolate `"schema"`
  - `{{this.table}}` to interpolate `"table"`
 - hooks are _appended_ to child configs. A hook defined directly beneath the project config will be applied to every model in that project. Hooks defined more specifically will be augmented, not overwritten.
 - hooks are not applied to ephemeral models

cc @jthandy 