### PR TITLE
Arbitrary Configs (v1)

### DIFF
--- a/dbt/compilation.py
+++ b/dbt/compilation.py
@@ -5,7 +5,7 @@ import jinja2
 from collections import defaultdict
 import dbt.project
 from dbt.source import Source
-from dbt.utils import find_model_by_fqn, find_model_by_name, dependency_projects, split_path, This
+from dbt.utils import find_model_by_fqn, find_model_by_name, dependency_projects, split_path, This, Var
 from dbt.linker import Linker
 import time
 import sqlparse
@@ -136,6 +136,7 @@ class Compiler(object):
         context['ref'] = self.__ref(linker, context, model, models)
         context['config'] = self.__model_config(model, linker)
         context['this'] = This(context['env']['schema'], model.immediate_name, model.name)
+        context['var'] = Var(model)
         context['compiled_at'] = time.strftime('%Y-%m-%d %H:%M:%S')
 
         hook_keys = ['pre-hook', 'post-hook']

--- a/dbt/model.py
+++ b/dbt/model.py
@@ -7,11 +7,11 @@ from dbt.templates import BaseCreateTemplate, DryCreateTemplate
 from dbt.utils import split_path
 import dbt.schema_tester
 import dbt.project
-from dbt.utils import This
+from dbt.utils import This, DBTConfigKeys
 
 class SourceConfig(object):
     Materializations = ['view', 'table', 'incremental', 'ephemeral']
-    ConfigKeys = ['enabled', 'materialized', 'dist', 'sort', 'sql_where', 'unique_key', 'sort_type', 'pre-hook', 'post-hook']
+    ConfigKeys = DBTConfigKeys
 
     def __init__(self, active_project, own_project, fqn):
         self.active_project = active_project
@@ -201,6 +201,9 @@ class DBTSource(object):
 
         return 'alter table "{schema}"."{tmp_name}" rename to "{final_name}"'.format(**opts)
 
+    @property
+    def nice_name(self):
+        return "{}.{}".format(self.fqn[0], self.fqn[-1])
 
 class Model(DBTSource):
     dbt_run_type = 'run'

--- a/dbt/model.py
+++ b/dbt/model.py
@@ -76,8 +76,14 @@ class SourceConfig(object):
 
     def get_project_config(self, project):
         # most configs are overwritten by a more specific config, but pre/post hooks are appended!
-        hook_fields = ['pre-hook', 'post-hook']
-        config = {k:[] for k in hook_fields} 
+        append_list_fields = ['pre-hook', 'post-hook']
+        extend_dict_fields = ['vars']
+
+        config = {}
+        for k in append_list_fields:
+            config[k] = []
+        for k in extend_dict_fields:
+            config[k] = {}
 
         model_configs = project['models']
 
@@ -89,11 +95,15 @@ class SourceConfig(object):
 
             relevant_configs = {key: level_config[key] for key in level_config if key in self.ConfigKeys}
 
-            for key in hook_fields:
+            for key in append_list_fields:
                 new_hooks = self.__get_hooks(relevant_configs, key)
                 config[key].extend([h for h in new_hooks if h not in config[key]])
 
-            clobber_configs = {k:v for (k,v) in relevant_configs.items() if k not in hook_fields}
+            for key in extend_dict_fields:
+                if key in relevant_configs:
+                    config[key].update(relevant_configs[key])
+
+            clobber_configs = {k:v for (k,v) in relevant_configs.items() if k not in append_list_fields and k not in extend_dict_fields}
             config.update(clobber_configs)
             model_configs = model_configs[level]
 


### PR DESCRIPTION
@jthandy super first cut of this, but I'd love to hear your initial thoughts.

I added a `var` function to the jinja context, so you can inform dbt that a variable is required. This function takes an optional second argument, the default value if a config is not provided.

In practice, this looks like:
```sql
-- dbt_modules/snowplow/models/transformed/page_pings.sql

with events as (
  select * from {{var('events')}}
)
select *
from events
where event = 'pp'
```

Since no default is provided here, dbt will throw a compiler error if an `events` parameter is not provided somewhere in the Snowplow config hierarchy at or above the `page_pings` model.

With a default, this looks like:
```sql
...
with events as (
  select * from {{var('events', 'atomic.events')}}
)
...
```

> Aside: I think i prefer the `{{ var('variable_name') }}` function to just interpolating the variable normally, ie. `{{ variable_name }}`. It feels somewhat more intentional as a function, but we can make it work either way. Keen to hear what you think about this.

---


Configuration ended up being a little tricker than expected -- the issue is that there's nothing to differentiate between sub-configs and variables. An example:

```yml
models:
  Snowplow:
    my_variable: 42 # this is a var
    transform:    # is "transform" a variable with the value {page_pings: {enabled: true, other_variable: true}}? Hard to tell!
      page_pings:
        other_variable: true # this is a var
        enabled: true
```

I ended up declaring a new "first-class" config option called `vars`, so the above example can be written:

```yml
models:
  Snowplow:
    vars:
      my_variable: 42
    transform:    
      page_pings:
        vars:
          other_variable: true
        enabled: true
```
These vars are combined, such that `page_pings` gets the config
```json
{
  "other_variable": true,
  "my_variable: 42
}
```

No ambiguity! LMK what you're thinking