### PR TITLE
more appropriate ref() scoping

### DIFF
--- a/dbt/compilation.py
+++ b/dbt/compilation.py
@@ -135,7 +135,9 @@ class Compiler(object):
             try:
                 return do_ref(*args)
             except RuntimeError as e:
-                print("Compiler error in {}".format(model.filepath))
+                root = os.path.relpath(model.root_dir, model.project['project-root'])
+                filepath = os.path.join(root, model.rel_filepath)
+                print("Compiler error in {}".format(filepath))
                 print("Enabled models:")
                 for m in all_models:
                     print(" - {}".format(".".join(m.fqn)))


### PR DESCRIPTION
If a dependency model tries to reference "up" the dep tree, the following error is thrown

```
Compiler error in dbt_modules/snowplow/models/transform/page_pings.sql
Enabled models:
 - Test DBT.base.accounts
 - Test DBT.base.events
 - dbt audit.audit
 - Snowplow.transform.page_pings
 - Snowplow.transform.page_views
 - Snowplow.transform.sessions
 - Snowplow.transform.sessions_basic
 - Snowplow.transform.sessions_exit_page
 - Snowplow.transform.sessions_landing_page
 - Snowplow.transform.sessions_source
 - Snowplow.transform.sessions_technology
Encountered an error:
Compilation error while compiling model Snowplow.page_pings
Model 'Test DBT.base.events' exists but cannot be referenced from dependency model 'Snowplow.transform.page_pings'
```