### PR TITLE
Feature/macros

### DIFF
--- a/dbt/model.py
+++ b/dbt/model.py
@@ -549,3 +549,15 @@ class Csv(DBTSource):
 
     def __repr__(self):
         return "<Csv {}.{}: {}>".format(self.project['name'], self.model_name, self.filepath)
+
+class Macro(DBTSource):
+    def __init__(self, project, target_dir, rel_filepath, own_project):
+        super(Macro, self).__init__(project, target_dir, rel_filepath, own_project)
+
+    def inject_contained_macros(self):
+        pass
+
+    def __repr__(self):
+        return "<Macro {}.{}: {}>".format(self.project['name'], self.name, self.filepath)
+
+

--- a/dbt/project.py
+++ b/dbt/project.py
@@ -7,6 +7,7 @@ import hashlib
 
 default_project_cfg = {
     'source-paths': ['models'],
+    'macro-paths': ['macros'],
     'data-paths': ['data'],
     'test-paths': ['test'],
     'target-path': 'target',

--- a/dbt/source.py
+++ b/dbt/source.py
@@ -55,7 +55,7 @@ class Source(object):
         return csvs
 
     def get_macros(self, macro_dirs):
-        "Get CSV files"
+        "Get Macro files"
         pattern = "[!.#~]*.sql"
         macros = [Macro(*macro) for macro in self.find(macro_dirs, pattern)]
         return macros

--- a/dbt/source.py
+++ b/dbt/source.py
@@ -1,7 +1,7 @@
 
 import os.path
 import fnmatch
-from dbt.model import Model, Analysis, TestModel, SchemaFile, Csv
+from dbt.model import Model, Analysis, TestModel, SchemaFile, Csv, Macro
 
 class Source(object):
     def __init__(self, project, own_project=None):
@@ -53,4 +53,10 @@ class Source(object):
         pattern = "[!.#~]*.csv"
         csvs = [Csv(*csv) for csv in self.find(csv_dirs, pattern)]
         return csvs
+
+    def get_macros(self, macro_dirs):
+        "Get CSV files"
+        pattern = "[!.#~]*.sql"
+        macros = [Macro(*macro) for macro in self.find(macro_dirs, pattern)]
+        return macros
 


### PR DESCRIPTION
Implement v1 of macros :)

Presently, macros from any package are globally scoped. Before this is ready for primetime, macros  should only be available to 1) the package which defines them 2) parent packages of the package which defines them.

The v1 cut of this involves adding a `macro-paths` config to `dbt_project.yml`

```yml
# dbt_project.yml

macro-paths: ["macros"]
...
models:
  'Fishtown Internal Analytics':
    pre-hook:
      - "{{ insert_audit_record('started') }}" # defined in the dbt-audit package
    post-hook:
      - "{{ insert_audit_record('completed') }}"

repositories:
    - https://github.com/analyst-collective/dbt-audit.git@development
```

This is a real config that really works in dev