### PR TITLE
two-step compilation for runtime vars

### DIFF
--- a/dbt/compilation.py
+++ b/dbt/compilation.py
@@ -151,6 +151,8 @@ class Compiler(object):
         context['config'] = self.__model_config(model, linker)
         context['this'] = This(context['env']['schema'], model.immediate_name, model.name)
         context['compiled_at'] = time.strftime('%Y-%m-%d %H:%M:%S')
+        context['run_started_at'] = '{{ run_started_at }}' # jinjaception
+        context['invocation_id']  = '{{ invocation_id }}'
         context['var'] = Var(model, context=context)
         return context
 

--- a/dbt/tracking.py
+++ b/dbt/tracking.py
@@ -55,9 +55,6 @@ def get_user():
 
     return user
 
-def get_invocation_id():
-    pass
-
 def get_options(args):
     exclude = ['cls', 'target', 'profile']
     options = {k:v for (k, v) in args.__dict__.items() if k not in exclude}


### PR DESCRIPTION
One problem with up-front compilation is that we can't inject runtime params into queries. One such runtime param is `{{ run_started_at }}`. This branch solves this problem by:
 - defining a `run_started_at` context var which is itself compiled to the string  `"{{ run_started_at }}"`
 - compiling the already-compiled model code a second time, interpolating only variables like `{{ run_started_at}}`

This branch implements `{{ run_started_at}}` and `{{ invocation_id}}` which are super useful for auditing dbt run invocations.