### PR TITLE
Fix/better concurrent output, --threads option

### DIFF
--- a/dbt/main.py
+++ b/dbt/main.py
@@ -74,6 +74,7 @@ def handle(args):
     sub = subs.add_parser('run', parents=[base_subparser])
     sub.add_argument('--dry', action='store_true', help="'dry run' models")
     sub.add_argument('--models', required=False, nargs='+', help="Specify the models to run. All models depending on these models will also be run")
+    sub.add_argument('--threads', type=int, required=False, help="Specify number of threads to use while executing models. Overrides settings in profiles.yml")
     sub.set_defaults(cls=run_task.RunTask, which='run')
 
     sub = subs.add_parser('seed', parents=[base_subparser])
@@ -83,6 +84,7 @@ def handle(args):
     sub = subs.add_parser('test', parents=[base_subparser])
     sub.add_argument('--skip-test-creates', action='store_true', help="Don't create temporary views to validate model SQL")
     sub.add_argument('--validate', action='store_true', help='Run constraint validations from schema.yml files')
+    sub.add_argument('--threads', type=int, required=False, help="Specify number of threads to use while executing tests. Overrides settings in profiles.yml")
     sub.set_defaults(cls=test_task.TestTask, which='test')
 
     if len(args) == 0: return p.print_help()

--- a/dbt/runner.py
+++ b/dbt/runner.py
@@ -198,13 +198,13 @@ class TestRunner(ModelRunner):
         return row[0]
 
 class RunManager(object):
-    def __init__(self, project, target_path, graph_type):
+    def __init__(self, project, target_path, graph_type, threads):
         self.logger = logging.getLogger(__name__)
         self.project = project
         self.target_path = target_path
         self.graph_type = graph_type
 
-        self.target = RedshiftTarget(self.project.run_environment())
+        self.target = RedshiftTarget(self.project.run_environment(), threads)
 
         if self.target.should_open_tunnel():
             print("Opening ssh tunnel to host {}... ".format(self.target.ssh_host), end="")

--- a/dbt/runner.py
+++ b/dbt/runner.py
@@ -322,37 +322,50 @@ class RunManager(object):
 
             models_to_execute = [model for model in model_list if not model.should_skip()]
 
-            for i, model in enumerate(models_to_execute):
-                msg = runner.pre_run_msg(model)
-                self.print_fancy_output_line(msg, 'RUN', get_idx(model), num_models)
+            threads = self.target.threads
+            num_models_this_batch = len(models_to_execute)
+            model_index = 0
 
-            wrapped_models_to_execute = [{"runner": runner, "model": model} for model in models_to_execute]
-            run_model_results = pool.map(self.safe_execute_model, wrapped_models_to_execute)
+            def on_complete(run_model_results):
+                for run_model_result in run_model_results:
+                    model_results.append(run_model_result)
 
-            for i, run_model_result in enumerate(run_model_results):
-                model_results.append(run_model_result)
+                    msg = runner.post_run_msg(run_model_result)
+                    status = runner.status(run_model_result)
+                    index = get_idx(run_model_result.model)
+                    self.print_fancy_output_line(msg, status, index, num_models, run_model_result.execution_time)
 
-                msg = runner.post_run_msg(run_model_result)
-                status = runner.status(run_model_result)
-                index = get_idx(run_model_result.model)
-                self.print_fancy_output_line(msg, status, index, num_models, run_model_result.execution_time)
+                    dbt.tracking.track_model_run({
+                        "invocation_id": dbt.tracking.invocation_id,
+                        "index": index,
+                        "total": num_models,
+                        "execution_time": run_model_result.execution_time,
+                        "run_status": run_model_result.status,
+                        "run_skipped": run_model_result.skip,
+                        "run_error": run_model_result.error,
+                        "model_materialization": run_model_result.model['materialized'],
+                        "model_id": run_model_result.model.hashed_name(),
+                        "hashed_contents": run_model_result.model.hashed_contents(),
+                    })
 
-                dbt.tracking.track_model_run({
-                    "invocation_id": dbt.tracking.invocation_id,
-                    "index": index,
-                    "total": num_models,
-                    "execution_time": run_model_result.execution_time,
-                    "run_status": run_model_result.status,
-                    "run_skipped": run_model_result.skip,
-                    "run_error": run_model_result.error,
-                    "model_materialization": run_model_result.model['materialized'],
-                    "model_id": run_model_result.model.hashed_name(),
-                    "hashed_contents": run_model_result.model.hashed_contents(),
-                })
+                    if run_model_result.errored:
+                        on_failure(run_model_result.model)
+                        print(run_model_result.error)
 
-                if run_model_result.errored:
-                    on_failure(run_model_result.model)
-                    print(run_model_result.error)
+            while model_index < num_models_this_batch:
+                local_models = []
+                for i in range(model_index, min(model_index + threads, num_models_this_batch)):
+                    model = models_to_execute[i]
+                    local_models.append(model)
+                    msg = runner.pre_run_msg(model)
+                    self.print_fancy_output_line(msg, 'RUN', get_idx(model), num_models)
+
+                wrapped_models_to_execute = [{"runner": runner, "model": model} for model in local_models]
+                map_result = pool.map_async(self.safe_execute_model, wrapped_models_to_execute, callback=on_complete)
+                map_result.wait()
+                run_model_results = map_result.get()
+
+                model_index += threads
 
         pool.close()
         pool.join()

--- a/dbt/targets.py
+++ b/dbt/targets.py
@@ -14,7 +14,7 @@ BAD_THREADS_ERROR = """Invalid value given for "threads" in active run-target.
 Value given was {supplied} but it should be an int between {min_val} and {max_val}"""
 
 class RedshiftTarget:
-    def __init__(self, cfg):
+    def __init__(self, cfg, threads=None):
         assert cfg['type'] == 'redshift'
         self.host = cfg['host']
         self.user = cfg['user']
@@ -22,7 +22,8 @@ class RedshiftTarget:
         self.port = cfg['port']
         self.dbname = cfg['dbname']
         self.schema = cfg['schema']
-        self.threads = self.__get_threads(cfg)
+
+        self.threads = self.__get_threads(cfg, threads)
 
         #self.ssh_host = cfg.get('ssh-host', None)
         self.ssh_host = None
@@ -73,8 +74,11 @@ class RedshiftTarget:
         #    self.ssh_tunnel.stop()
         pass
 
-    def __get_threads(self, cfg):
-        supplied = cfg.get('threads', 1)
+    def __get_threads(self, cfg, cli_threads=None):
+        if cli_threads is None:
+            supplied = cfg.get('threads', 1)
+        else:
+            supplied = cli_threads
 
         bad_threads_error = RuntimeError(BAD_THREADS_ERROR.format(supplied=supplied, min_val=THREAD_MIN, max_val=THREAD_MAX))
 

--- a/dbt/task/run.py
+++ b/dbt/task/run.py
@@ -25,7 +25,7 @@ class RunTask:
     def run(self):
         graph_type = self.compile()
 
-        runner = RunManager(self.project, self.project['target-path'], graph_type)
+        runner = RunManager(self.project, self.project['target-path'], graph_type, self.args.threads)
 
         if self.args.dry:
             results = runner.dry_run(self.args.models)

--- a/dbt/task/test.py
+++ b/dbt/task/test.py
@@ -33,7 +33,7 @@ class TestTask:
 
     def run(self):
         self.compile()
-        runner = RunManager(self.project, self.project['target-path'], 'build')
+        runner = RunManager(self.project, self.project['target-path'], 'build', self.args.threads)
         runner.run_tests()
 
         print("Done!")


### PR DESCRIPTION
We suspected that a bug existed which caused more threads than specified to execute at a given time. This doesn't happen, but the dbt output is particularly misleading! This branch makes the dbt output more indicative of what is actually happening.

In addition, this branch adds the `--threads` command line option to dbt. The `--threads` arg overrides the `threads` config specified in `dbt_project.yml`. If neither is provided, the default is 1 thread.