### PR TITLE
use configs defined at the root model level

### DIFF
--- a/dbt/model.py
+++ b/dbt/model.py
@@ -13,6 +13,9 @@ class SourceConfig(object):
     Materializations = ['view', 'table', 'incremental', 'ephemeral']
     ConfigKeys = DBTConfigKeys
 
+    AppendListFields  = ['pre-hook', 'post-hook']
+    ExtendDictFields = ['vars']
+
     def __init__(self, active_project, own_project, fqn):
         self.active_project = active_project
         self.own_project = own_project
@@ -80,15 +83,24 @@ class SourceConfig(object):
             hooks.append(hook)
         return hooks
 
+    def smart_update(self, mutable_config, new_configs):
+        relevant_configs = {key: new_configs[key] for key in new_configs if key in self.ConfigKeys}
+        for key in SourceConfig.AppendListFields:
+            new_hooks = self.__get_hooks(relevant_configs, key)
+            mutable_config[key].extend([h for h in new_hooks if h not in mutable_config[key]])
+
+        for key in SourceConfig.ExtendDictFields:
+            dict_val = relevant_configs.get(key, {})
+            mutable_config[key].update(dict_val)
+
+        return relevant_configs
+
     def get_project_config(self, project):
         # most configs are overwritten by a more specific config, but pre/post hooks are appended!
-        append_list_fields = ['pre-hook', 'post-hook']
-        extend_dict_fields = ['vars']
-
         config = {}
-        for k in append_list_fields:
+        for k in SourceConfig.AppendListFields:
             config[k] = []
-        for k in extend_dict_fields:
+        for k in SourceConfig.ExtendDictFields:
             config[k] = {}
 
         model_configs = project['models']
@@ -96,23 +108,19 @@ class SourceConfig(object):
         if model_configs is None:
             return config
 
+        # mutates config
+        self.smart_update(config, model_configs)
+
         fqn = self.fqn[:]
         for level in fqn:
             level_config = model_configs.get(level, None)
             if level_config is None:
                 break
 
-            relevant_configs = {key: level_config[key] for key in level_config if key in self.ConfigKeys}
+            # mutates config
+            relevant_configs = self.smart_update(config, level_config)
 
-            for key in append_list_fields:
-                new_hooks = self.__get_hooks(relevant_configs, key)
-                config[key].extend([h for h in new_hooks if h not in config[key]])
-
-            for key in extend_dict_fields:
-                dict_val = relevant_configs.get(key, {})
-                config[key].update(dict_val)
-
-            clobber_configs = {k:v for (k,v) in relevant_configs.items() if k not in append_list_fields and k not in extend_dict_fields}
+            clobber_configs = {k:v for (k,v) in relevant_configs.items() if k not in SourceConfig.AppendListFields and k not in SourceConfig.ExtendDictFields}
             config.update(clobber_configs)
             model_configs = model_configs[level]
 


### PR DESCRIPTION
With this branch, configs can be defined at the `models` root config! They work like all other configs, so `enabled`, `materialized`, etc get completely overriden, model `hooks` get appended, and `vars` get extended!

In practice, this looks like:

```yml
models:
  post-hook:
    - 'grant select on table {{this}} to looker'
  "My Project":
    post-hook: "insert into..."
```

In this example, both the `grant` and the `insert` will be applied to models in the "My Project" project.