### PR TITLE
Feature/first class pg

### DIFF
--- a/dbt/runner.py
+++ b/dbt/runner.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from dbt.compilation import Compiler
 from dbt.linker import Linker
 from dbt.templates import BaseCreateTemplate
-from dbt.targets import RedshiftTarget
+import dbt.targets
 from dbt.source import Source
 from dbt.utils import find_model_by_fqn, find_model_by_name, dependency_projects
 from dbt.compiled_model import make_compiled_model
@@ -205,7 +205,7 @@ class RunManager(object):
         self.target_path = target_path
         self.graph_type = graph_type
 
-        self.target = RedshiftTarget(self.project.run_environment())
+        self.target = dbt.targets.get_target(self.project.run_environment())
 
         if self.target.should_open_tunnel():
             print("Opening ssh tunnel to host {}... ".format(self.target.ssh_host), end="")

--- a/dbt/schema_tester.py
+++ b/dbt/schema_tester.py
@@ -1,6 +1,6 @@
 import os
 
-from dbt.targets import RedshiftTarget
+import dbt.targets
 
 import psycopg2
 import logging
@@ -58,7 +58,7 @@ class SchemaTester(object):
 
     def get_target(self):
         target_cfg = self.project.run_environment()
-        return RedshiftTarget(target_cfg)
+        return dbt.targets.get_target(target_cfg)
 
     def execute_query(self, model, sql):
         target = self.get_target()

--- a/dbt/seeder.py
+++ b/dbt/seeder.py
@@ -6,13 +6,13 @@ from sqlalchemy.dialects import postgresql as postgresql_dialect
 import psycopg2
 
 from dbt.source import Source
-from dbt.targets import RedshiftTarget
+import dbt.targets
 
 class Seeder:
     def __init__(self, project):
         self.project = project
         run_environment = self.project.run_environment()
-        self.target = RedshiftTarget(run_environment)
+        self.target = dbt.targets.get_target(run_environment)
 
     def find_csvs(self):
         return Source(self.project).get_csvs(self.project['data-paths'])

--- a/dbt/targets.py
+++ b/dbt/targets.py
@@ -13,9 +13,9 @@ THREAD_MAX = 8
 BAD_THREADS_ERROR = """Invalid value given for "threads" in active run-target.
 Value given was {supplied} but it should be an int between {min_val} and {max_val}"""
 
-class RedshiftTarget:
+class BaseSQLTarget:
     def __init__(self, cfg):
-        assert cfg['type'] == 'redshift'
+        self.target_type = cfg['type']
         self.host = cfg['host']
         self.user = cfg['user']
         self.password = cfg['pass']
@@ -63,7 +63,7 @@ class RedshiftTarget:
         return False
 
     # make the user explicitly call this function to enable the ssh tunnel
-    # we don't want it to be automatically opened any time someone makes a RedshiftTarget()
+    # we don't want it to be automatically opened any time someone makes a new target
     def open_tunnel_if_needed(self):
         #self.ssh_tunnel = self.__open_tunnel()
         pass
@@ -105,3 +105,41 @@ class RedshiftTarget:
     def rollback(self):
         if self.handle is not None:
             self.handle.rollback()
+
+    @property
+    def type(self):
+        return self.target_type
+
+class RedshiftTarget(BaseSQLTarget):
+    def __init__(self, cfg):
+        super(RedshiftTarget, self).__init__(cfg)
+
+    @property
+    def context(self):
+        return {
+            "sql_now": "getdate()"
+        }
+
+class PostgresTarget(BaseSQLTarget):
+    def __init__(self, cfg):
+        super(PostgresTarget, self).__init__(cfg)
+
+    @property
+    def context(self):
+        return {
+            "sql_now": "clock_timestamp()"
+        }
+
+target_map = {
+    'postgres': PostgresTarget,
+    'redshift': RedshiftTarget
+}
+
+def get_target(cfg):
+    target_type = cfg['type']
+    if target_type in target_map:
+        klass = target_map[target_type]
+        return klass(cfg)
+    else:
+        valid_csv = ", ".join(["'{}'".format(t) for t in target_map])
+        raise RuntimeError("Invalid target type provided: '{}'. Must be one of {}".format(target_type, valid_csv))


### PR DESCRIPTION
Previously, the only target`type` option was `"redshift"`. Now, this `type` field can be set to `"postgres"` instead. Everything works almost exactly the same, but this differentiation is used for injecting variables into the compilation context.

In this branch, one new context variable is added, `sql_now`. In Redshift, this expands to `getdate()` and in Postgres, it expands to `clock_timestamp()`. While `now()` is more canonical (I think?), `now()` reflects the time of the start of the transaction, whereas `clock_timestamp() reflects the wall-clock time when the statement is executed. The primary use case for `sql_now` is for pre-and-post-hook audit records, we definitely want wall-clock time.

```yml
# profiles.yml
user:
  outputs:
    dev:
      type: postgres
      host: localhost
      user: Drew
....
```

An example of `sql_where` (and macros):
```sql
# audit_macros.sql
{% set audit_table = ref('audit') %}

{% macro log_run_with_status(status) %}

insert into {{ audit_table }}
    (invocation_id, run_started_at, run_at, model, status)
values
    ('{{ invocation_id }}', '{{ run_started_at }}', {{ sql_now }}, '{{ this.name }}', '{{ status }}')
--                                                        ^
--                                                        |
--                                      sql_now ----------+

{% endmacro %}
```

Which compiles to:

```sql
insert into "analytics"."audit"
    (invocation_id, run_started_at, run_at, model, status)
values
    ('{{ invocation_id }}', '{{ run_started_at }}', clock_timestamp(), 'accounts', 'started');
```

In sum, this is a pretty minor change, but it has pretty big ramifications for how we think about packages. Curious to hear your thoughts, @jthandy  