### PR TITLE
make tests work in development + master

### DIFF
--- a/test/integration/006_simple_dependency_test/test_simple_dependency_with_configs.py
+++ b/test/integration/006_simple_dependency_test/test_simple_dependency_with_configs.py
@@ -28,7 +28,7 @@ class TestSimpleDependencyWithConfigs(BaseTestSimpleDependencyWithConfigs):
 
             },
             "repositories": [
-                'https://github.com/fishtown-analytics/dbt-integration-project@configs'
+                'https://github.com/fishtown-analytics/dbt-integration-project@with-configs'
             ]
         }
 
@@ -61,7 +61,7 @@ class TestSimpleDependencyWithOverriddenConfigs(BaseTestSimpleDependencyWithConf
 
             },
             "repositories": [
-                'https://github.com/fishtown-analytics/dbt-integration-project@configs'
+                'https://github.com/fishtown-analytics/dbt-integration-project@with-configs'
             ]
         }
 
@@ -97,7 +97,7 @@ class TestSimpleDependencyWithModelSpecificOverriddenConfigs(BaseTestSimpleDepen
 
             },
             "repositories": [
-                'https://github.com/fishtown-analytics/dbt-integration-project@configs'
+                'https://github.com/fishtown-analytics/dbt-integration-project@with-configs'
             ]
         }
 
@@ -141,7 +141,7 @@ class TestSimpleDependencyWithModelSpecificOverriddenConfigs(BaseTestSimpleDepen
 
             },
             "repositories": [
-                'https://github.com/fishtown-analytics/dbt-integration-project@configs'
+                'https://github.com/fishtown-analytics/dbt-integration-project@with-configs'
             ]
         }
 


### PR DESCRIPTION
We use the [dbt-integration-project](https://github.com/fishtown-analytics/dbt-integration-project) repo to run integration tests. New tests (currently in `development`) required changes to the `configs` branch of the `dbt-integration-project` repo, but these changes were inconsistent with the tests that are already in `master`.

Rather than merging the `development` code into `master` (to fix the tests), I reverted the changes to the `configs` branch of the `dbt-integration-project` repo and created a new `with-configs` branch. This means that:
 - `master` tests should no longer be failing
 - `development` tests will keep passing
 - a future merge of `development` into `master` will keep all tests passing