### PR TITLE
change: add `--debug` flag, replace all calls to `print()` with a streamhandler logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## dbt 0.6.1 (unreleased)
+
+#### Changes
+
+- add `--debug` flag, replace calls to `print()` with a global logger ([#256](https://github.com/analyst-collective/dbt/pull/256))
+
 ## dbt release 0.6.0
 
 ### tl;dr

--- a/dbt/compilation.py
+++ b/dbt/compilation.py
@@ -1,17 +1,19 @@
-
 import os
 import fnmatch
 import jinja2
 from collections import defaultdict
-import dbt.project
-from dbt.source import Source
-from dbt.utils import find_model_by_fqn, find_model_by_name, dependency_projects, split_path, This, Var, compiler_error, to_string
-from dbt.linker import Linker
-from dbt.runtime import RuntimeContext
-import dbt.targets
-import dbt.templates
 import time
 import sqlparse
+
+import dbt.project
+import dbt.targets
+import dbt.templates
+
+from dbt.linker import Linker
+from dbt.logger import GLOBAL_LOGGER as logger
+from dbt.runtime import RuntimeContext
+from dbt.source import Source
+from dbt.utils import find_model_by_fqn, find_model_by_name, dependency_projects, split_path, This, Var, compiler_error, to_string
 
 CompilableEntities = ["models", "data tests", "schema tests", "archives", "analyses"]
 

--- a/dbt/compilation.py
+++ b/dbt/compilation.py
@@ -174,10 +174,10 @@ class Compiler(object):
             except RuntimeError as e:
                 root = os.path.relpath(model.root_dir, model.project['project-root'])
                 filepath = os.path.join(root, model.rel_filepath)
-                print("Compiler error in {}".format(filepath))
-                print("Enabled models:")
+                logger.info("Compiler error in {}".format(filepath))
+                logger.info("Enabled models:")
                 for m in all_models:
-                    print(" - {}".format(".".join(m.fqn)))
+                    logger.info(" - {}".format(".".join(m.fqn)))
                 raise e
 
         return wrapped_do_ref

--- a/dbt/deprecations.py
+++ b/dbt/deprecations.py
@@ -7,12 +7,12 @@ class DBTDeprecation(object):
     def show(self, *args, **kwargs):
         if self.name not in active_deprecations:
             desc = self.description.format(**kwargs)
-            print("* Deprecation Warning: {}\n".format(desc))
+            logger.info("* Deprecation Warning: {}\n".format(desc))
             active_deprecations.add(self.name)
 
 class DBTRunTargetDeprecation(DBTDeprecation):
     name = 'run-target'
-    description = """profiles.yml configuration option 'run-target' is deprecated. Please use 'target' instead. 
+    description = """profiles.yml configuration option 'run-target' is deprecated. Please use 'target' instead.
   The 'run-target' option will be removed (in favor of 'target') in DBT version 0.7.0"""
 
 class DBTInvalidPackageName(DBTDeprecation):

--- a/dbt/deprecations.py
+++ b/dbt/deprecations.py
@@ -1,4 +1,4 @@
-
+from dbt.logger import GLOBAL_LOGGER as logger
 
 class DBTDeprecation(object):
     name = None

--- a/dbt/logger.py
+++ b/dbt/logger.py
@@ -1,43 +1,24 @@
 import logging
-import logging.config
-import os
+import sys
 
-def make_log_dir_if_missing(log_dir):
-    if not os.path.exists(log_dir):
-        os.makedirs(log_dir)
+# disable logs from other modules, excepting ERROR logs
+logging.getLogger('contracts').setLevel(logging.ERROR)
+logging.getLogger('requests').setLevel(logging.ERROR)
+logging.getLogger('urllib3').setLevel(logging.ERROR)
 
-def getLogger(log_dir, name):
-    make_log_dir_if_missing(log_dir)
-    filename = "dbt.log"
-    base_log_path = os.path.join(log_dir, filename)
 
-    dictLogConfig = {
-        "version":1,
-        "handlers": {
-            "fileHandler":{
-                "class":"logging.handlers.TimedRotatingFileHandler",
-                "formatter":"fileFormatter",
-                "when": "d",  # rotate daily
-                "interval": 1,
-                "backupCount": 7,
-                "filename": base_log_path
-            },
-        },
-        "loggers":{
-            "dbt":{
-                "handlers":["fileHandler"],
-                "level":"DEBUG",
-                "propagate": False
-            }
-        },
+# create a global console logger for dbt
+handler = logging.StreamHandler(sys.stdout)
+handler.setFormatter(logging.Formatter('%(message)s'))
 
-        "formatters":{
-            "fileFormatter":{
-                "format":"%(asctime)s - %(name)s - %(levelname)s - %(threadName)s - %(message)s"
-            }
-        }
-    }
-    logging.config.dictConfig(dictLogConfig)
-    logger = logging.getLogger(name)
-    return logger
+logger = logging.getLogger()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
 
+
+def initialize_logger(debug_mode=False,):
+    if debug_mode:
+        handler.setFormatter(logging.Formatter('%(asctime)-18s: %(message)s'))
+        logger.setLevel(logging.DEBUG)
+
+GLOBAL_LOGGER = logger

--- a/dbt/runner.py
+++ b/dbt/runner.py
@@ -10,6 +10,7 @@ import re
 import yaml
 from datetime import datetime
 
+from dbt.logger import GLOBAL_LOGGER as logger
 from dbt.compilation import compile_string
 from dbt.linker import Linker
 from dbt.templates import BaseCreateTemplate
@@ -231,7 +232,7 @@ class DryRunner(ModelRunner):
             relation_type = 'table' if model.materialization == 'incremental' else 'view'
             self.schema_helper.drop(schema_name, relation_type, model.name)
             count_dropped += 1
-        print("Dropped {} dry-run models".format(count_dropped))
+        logger.info("Dropped {} dry-run models".format(count_dropped))
 
 class TestRunner(ModelRunner):
     run_type = 'test'
@@ -333,7 +334,6 @@ class ArchiveRunner(BaseRunner):
 
 class RunManager(object):
     def __init__(self, project, target_path, graph_type, args):
-        self.logger = logging.getLogger(__name__)
         self.project = project
         self.target_path = target_path
         self.graph_type = graph_type
@@ -342,10 +342,10 @@ class RunManager(object):
         self.target = dbt.targets.get_target(self.project.run_environment(), self.args.threads)
 
         if self.target.should_open_tunnel():
-            print("Opening ssh tunnel to host {}... ".format(self.target.ssh_host), end="")
+            logger.info("Opening ssh tunnel to host {}... ".format(self.target.ssh_host), end="")
             sys.stdout.flush()
             self.target.open_tunnel_if_needed()
-            print("Connected")
+            logger.info("Connected")
 
 
         self.schema = dbt.schema.Schema(self.project, self.target)
@@ -369,7 +369,7 @@ class RunManager(object):
         return linker
 
     def execute_model(self, runner, model):
-        self.logger.info("executing model %s", model)
+        logger.debug("executing model %s", model)
 
         result = runner.execute(self.target, model)
         return result
@@ -385,12 +385,12 @@ class RunManager(object):
         except (RuntimeError, psycopg2.ProgrammingError, psycopg2.InternalError) as e:
             error = "Error executing {filepath}\n{error}".format(filepath=model['build_path'], error=str(e).strip())
             status = "ERROR"
-            self.logger.exception(error)
+            logger.exception(error)
             if type(e) == psycopg2.InternalError and ABORTED_TRANSACTION_STRING == e.diag.message_primary:
                 return RunModelResult(model, error=ABORTED_TRANSACTION_STRING, status="SKIP")
         except Exception as e:
             error = "Unhandled error while executing {filepath}\n{error}".format(filepath=model['build_path'], error=str(e).strip())
-            self.logger.exception(error)
+            logger.exception(error)
             raise e
 
         execution_time = time.time() - start_time
@@ -428,27 +428,27 @@ class RunManager(object):
         if execution_time is None:
             status_time = ""
         else:
-            status_time = " in {execution_time:0.2f}s".format(execution_time=execution_time) 
+            status_time = " in {execution_time:0.2f}s".format(execution_time=execution_time)
 
         output = "{justified} [{status}{status_time}]".format(justified=justified, status=status, status_time=status_time)
-        print(output)
+        logger.info(output)
 
     def execute_models(self, runner, model_dependency_list, on_failure):
         flat_models = list(itertools.chain.from_iterable(model_dependency_list))
 
         num_models = len(flat_models)
         if num_models == 0:
-            print("WARNING: Nothing to do. Try checking your model configs and running `dbt compile`".format(self.target_path))
+            logger.info("WARNING: Nothing to do. Try checking your model configs and running `dbt compile`".format(self.target_path))
             return []
 
         num_threads = self.target.threads
-        print("Concurrency: {} threads (target='{}')".format(num_threads, self.project.get_target().get('name')))
-        print("Running!")
+        logger.info("Concurrency: {} threads (target='{}')".format(num_threads, self.project.get_target().get('name')))
+        logger.info("Running!")
 
         pool = ThreadPool(num_threads)
 
-        print()
-        print(runner.pre_run_all_msg(flat_models))
+        logger.info()
+        logger.info(runner.pre_run_all_msg(flat_models))
         runner.pre_run_all(flat_models, self.context)
 
         fqn_to_id_map = {model.fqn: i + 1 for (i, model) in enumerate(flat_models)}
@@ -494,7 +494,7 @@ class RunManager(object):
 
                     if run_model_result.errored:
                         on_failure(run_model_result.model)
-                        print(run_model_result.error)
+                        logger.info(run_model_result.error)
 
             while model_index < num_models_this_batch:
                 local_models = []
@@ -514,14 +514,14 @@ class RunManager(object):
         pool.close()
         pool.join()
 
-        print()
-        print(runner.post_run_all_msg(model_results))
+        logger.info()
+        logger.info(runner.post_run_all_msg(model_results))
         runner.post_run_all(flat_models, model_results, self.context)
 
         return model_results
 
     def run_from_graph(self, runner, limit_to):
-        print("Loading dependency graph file")
+        logger.info("Loading dependency graph file")
         linker = self.deserialize_graph()
         compiled_models = [make_compiled_model(fqn, linker.get_node(fqn)) for fqn in linker.nodes()]
         relevant_compiled_models = [m for m in compiled_models if m.is_type(runner.run_type)]
@@ -535,12 +535,12 @@ class RunManager(object):
         schema_name = self.target.schema
 
 
-        print("Connecting to redshift")
+        logger.info("Connecting to redshift")
         try:
             self.schema.create_schema_if_not_exists(schema_name)
         except psycopg2.OperationalError as e:
-            print("ERROR: Could not connect to the target database. Try `dbt debug` for more information")
-            print(str(e))
+            logger.info("ERROR: Could not connect to the target database. Try `dbt debug` for more information")
+            logger.info(str(e))
             sys.exit(1)
 
         existing = self.schema.query_for_existing(schema_name);
@@ -563,10 +563,10 @@ class RunManager(object):
             raise
         finally:
             if self.target.should_open_tunnel():
-                print("Closing SSH tunnel... ", end="")
+                logger.info("Closing SSH tunnel... ", end="")
                 sys.stdout.flush()
                 self.target.cleanup()
-                print("Done")
+                logger.info("Done")
 
 
     def run_tests_from_graph(self, test_schemas, test_data):
@@ -575,12 +575,12 @@ class RunManager(object):
 
         schema_name = self.target.schema
 
-        print("Connecting to redshift")
+        logger.info("Connecting to redshift")
         try:
             self.schema.create_schema_if_not_exists(schema_name)
         except psycopg2.OperationalError as e:
-            print("ERROR: Could not connect to the target database. Try `dbt debug` for more information")
-            print(str(e))
+            logger.info("ERROR: Could not connect to the target database. Try `dbt debug` for more information")
+            logger.info(str(e))
             sys.exit(1)
 
         test_runner = TestRunner(self.project, self.schema)
@@ -626,5 +626,3 @@ class RunManager(object):
     def run_archive(self):
         runner = ArchiveRunner(self.project, self.schema)
         return self.safe_run_from_graph(runner, None)
-
-

--- a/dbt/runner.py
+++ b/dbt/runner.py
@@ -447,7 +447,7 @@ class RunManager(object):
 
         pool = ThreadPool(num_threads)
 
-        logger.info()
+        logger.info("")
         logger.info(runner.pre_run_all_msg(flat_models))
         runner.pre_run_all(flat_models, self.context)
 
@@ -514,7 +514,7 @@ class RunManager(object):
         pool.close()
         pool.join()
 
-        logger.info()
+        logger.info("")
         logger.info(runner.post_run_all_msg(model_results))
         runner.post_run_all(flat_models, model_results, self.context)
 

--- a/dbt/seeder.py
+++ b/dbt/seeder.py
@@ -5,8 +5,9 @@ from csvkit import table as csv_table, sql as csv_sql
 from sqlalchemy.dialects import postgresql as postgresql_dialect
 import psycopg2
 
-from dbt.source import Source
 import dbt.targets
+from dbt.source import Source
+from dbt.logger import GLOBAL_LOGGER as logger
 
 class Seeder:
     def __init__(self, project):

--- a/dbt/seeder.py
+++ b/dbt/seeder.py
@@ -19,18 +19,18 @@ class Seeder:
 
     def drop_table(self, cursor, schema, table):
         sql = 'drop table if exists "{schema}"."{table}" cascade'.format(schema=schema, table=table)
-        print("Dropping table {}.{}".format(schema, table))
+        logger.info("Dropping table {}.{}".format(schema, table))
         cursor.execute(sql)
 
     def truncate_table(self, cursor, schema, table):
         sql = 'truncate table "{schema}"."{table}"'.format(schema=schema, table=table)
-        print("Truncating table {}.{}".format(schema, table))
+        logger.info("Truncating table {}.{}".format(schema, table))
         cursor.execute(sql)
 
     def create_table(self, cursor, schema, table, virtual_table):
         sql_table = csv_sql.make_table(virtual_table, db_schema=schema)
         create_table_sql = csv_sql.make_create_table_statement(sql_table, dialect='postgresql')
-        print("Creating table {}.{}".format(schema, table))
+        logger.info("Creating table {}.{}".format(schema, table))
         cursor.execute(create_table_sql)
 
     def insert_into_table(self, cursor, schema, table, virtual_table):
@@ -51,7 +51,7 @@ class Seeder:
           record_csv_wrapped = "({})".format(record_csv)
           records.append(record_csv_wrapped)
         insert_sql = "{} {}".format(base_insert, ",\n".join(records))
-        print("Inserting {} records into table {}.{}".format(len(virtual_table.to_rows()), schema, table))
+        logger.info("Inserting {} records into table {}.{}".format(len(virtual_table.to_rows()), schema, table))
         cursor.execute(insert_sql)
 
     def existing_tables(self, cursor, schema):
@@ -60,7 +60,7 @@ class Seeder:
         cursor.execute(sql)
         existing = set([row[0] for row in cursor.fetchall()])
         return existing
-    
+
     def do_seed(self, schema, cursor, drop_existing):
         existing_tables = self.existing_tables(cursor, schema)
 
@@ -83,10 +83,10 @@ class Seeder:
             try:
                 self.insert_into_table(cursor, schema, table_name, virtual_table)
             except psycopg2.ProgrammingError as e:
-                print('Encountered an error while inserting into table "{}"."{}"'.format(schema, table_name))
-                print('Check for formatting errors in {}'.format(csv.filepath))
-                print('Try --drop-existing to delete and recreate the table instead')
-                print(str(e))
+                logger.info('Encountered an error while inserting into table "{}"."{}"'.format(schema, table_name))
+                logger.info('Check for formatting errors in {}'.format(csv.filepath))
+                logger.info('Try --drop-existing to delete and recreate the table instead')
+                logger.info(str(e))
 
 
     def seed(self, drop_existing=False):

--- a/dbt/task/archive.py
+++ b/dbt/task/archive.py
@@ -13,11 +13,10 @@ class ArchiveTask:
         compiler = Compiler(self.project, self.create_template, self.args)
         compiler.initialize()
         compiled = compiler.compile_archives()
-        print("Compiled {} archives".format(len(compiled)))
+        logger.info("Compiled {} archives".format(len(compiled)))
 
     def run(self):
         self.compile()
         runner = RunManager(self.project, self.project['target-path'], self.create_template.label, self.args)
 
         results = runner.run_archive()
-

--- a/dbt/task/archive.py
+++ b/dbt/task/archive.py
@@ -2,6 +2,7 @@
 from dbt.runner import RunManager
 from dbt.templates import ArchiveInsertTemplate
 from dbt.compilation import Compiler
+from dbt.logger import GLOBAL_LOGGER as logger
 
 class ArchiveTask:
     def __init__(self, args, project):

--- a/dbt/task/compile.py
+++ b/dbt/task/compile.py
@@ -19,4 +19,4 @@ class CompileTask:
         results = compiler.compile(limit_to=CompilableEntities)
 
         stat_line = ", ".join(["{} {}".format(results[k], k) for k in CompilableEntities])
-        print("Compiled {}".format(stat_line))
+        logger.info("Compiled {}".format(stat_line))

--- a/dbt/task/compile.py
+++ b/dbt/task/compile.py
@@ -1,6 +1,7 @@
 
 from dbt.compilation import Compiler, CompilableEntities
 from dbt.templates import BaseCreateTemplate, DryCreateTemplate
+from dbt.logger import GLOBAL_LOGGER as logger
 
 
 class CompileTask:

--- a/dbt/task/debug.py
+++ b/dbt/task/debug.py
@@ -1,4 +1,5 @@
 import pprint
+from dbt.logger import GLOBAL_LOGGER as logger
 
 
 class DebugTask:
@@ -9,4 +10,6 @@ class DebugTask:
     def run(self):
         logger.info("args: {}".format(self.args))
         logger.info("project: ")
+
+        # TODO: switch this out for a log statement
         pprint.pprint(self.project)

--- a/dbt/task/debug.py
+++ b/dbt/task/debug.py
@@ -7,6 +7,6 @@ class DebugTask:
         self.project = project
 
     def run(self):
-        print("args: {}".format(self.args))
-        print("project: ")
+        logger.info("args: {}".format(self.args))
+        logger.info("project: ")
         pprint.pprint(self.project)

--- a/dbt/task/deps.py
+++ b/dbt/task/deps.py
@@ -17,7 +17,7 @@ class DepsTask:
         self.project = project
 
     def __checkout_branch(self, branch, full_path):
-        print("  checking out branch {}".format(branch))
+        logger.info("  checking out branch {}".format(branch))
         proc = subprocess.Popen(
             ['git', 'checkout', branch],
             cwd=full_path,
@@ -38,7 +38,7 @@ class DepsTask:
         folder = None
         if exists:
             folder = exists.group(1)
-            print("updating existing dependency {}".format(folder))
+            logger.info("updating existing dependency {}".format(folder))
             full_path = os.path.join(self.project['modules-path'], folder)
             proc = subprocess.Popen(
                 ['git', 'fetch', '--all'],
@@ -59,7 +59,7 @@ class DepsTask:
             matches = re.match("Cloning into '(.+)'", err.decode('utf-8'))
             folder = matches.group(1)
             full_path = os.path.join(self.project['modules-path'], folder)
-            print("pulled new dependency {}".format(folder))
+            logger.info("pulled new dependency {}".format(folder))
             if branch is not None:
                 self.__checkout_branch(branch, full_path)
 
@@ -97,7 +97,7 @@ class DepsTask:
 
             try:
                 if repo_folder in processed_repos:
-                    print("skipping already processed dependency {}".format(repo_folder))
+                    logger.info("skipping already processed dependency {}".format(repo_folder))
                 else:
                     dep_folder = self.__pull_repo(repo, branch)
                     dep_project = project.read_project(
@@ -109,7 +109,7 @@ class DepsTask:
                     self.__pull_deps_recursive(dep_project['repositories'], processed_repos, i+1)
             except IOError as e:
                 if e.errno == errno.ENOENT:
-                    print("'{}' is not a valid dbt project - dbt_project.yml not found".format(repo))
+                    logger.info("'{}' is not a valid dbt project - dbt_project.yml not found".format(repo))
                     exit(1)
                 else:
                     raise e

--- a/dbt/task/deps.py
+++ b/dbt/task/deps.py
@@ -6,6 +6,8 @@ import pprint
 import subprocess
 import dbt.project as project
 
+from dbt.logger import GLOBAL_LOGGER as logger
+
 def folder_from_git_remote(remote_spec):
     start = remote_spec.rfind('/') + 1
     end = len(remote_spec) - (4 if remote_spec.endswith('.git') else 0)

--- a/dbt/task/run.py
+++ b/dbt/task/run.py
@@ -1,10 +1,11 @@
-
 from __future__ import print_function
 
 import os
-from dbt.templates import DryCreateTemplate, BaseCreateTemplate
-from dbt.runner import RunManager
+
 from dbt.compilation import Compiler, CompilableEntities
+from dbt.logger import GLOBAL_LOGGER as logger
+from dbt.runner import RunManager
+from dbt.templates import DryCreateTemplate, BaseCreateTemplate
 
 THREAD_LIMIT = 9
 

--- a/dbt/task/run.py
+++ b/dbt/task/run.py
@@ -20,7 +20,7 @@ class RunTask:
         results = compiler.compile(limit_to=['models'] )
 
         stat_line = ", ".join(["{} {}".format(results[k], k) for k in CompilableEntities])
-        print("Compiled {}".format(stat_line))
+        logger.info("Compiled {}".format(stat_line))
 
         return create_template.label
 
@@ -39,6 +39,4 @@ class RunTask:
         errored = len([r for r in results if r.errored])
         skipped = len([r for r in results if r.skipped])
 
-
-        print()
-        print("Done. PASS={passed} ERROR={errored} SKIP={skipped} TOTAL={total}".format(total=total, passed=passed, errored=errored, skipped=skipped))
+        logger.info("Done. PASS={passed} ERROR={errored} SKIP={skipped} TOTAL={total}".format(total=total, passed=passed, errored=errored, skipped=skipped))

--- a/dbt/task/test.py
+++ b/dbt/task/test.py
@@ -29,7 +29,7 @@ class TestTask:
         results = compiler.compile(limit_to=['tests'])
 
         stat_line = ", ".join(["{} {}".format(results[k], k) for k in CompilableEntities])
-        print("Compiled {}".format(stat_line))
+        logger.info("Compiled {}".format(stat_line))
 
         return compiler
 
@@ -46,5 +46,5 @@ class TestTask:
         else:
             raise RuntimeError("unexpected")
 
-        print("Done!")
+        logger.info("Done!")
         return res

--- a/dbt/task/test.py
+++ b/dbt/task/test.py
@@ -7,6 +7,7 @@ from dbt.compilation import Compiler, CompilableEntities
 from dbt.templates import DryCreateTemplate, BaseCreateTemplate
 from dbt.runner import RunManager
 from dbt.schema_tester import SchemaTester
+from dbt.logger import GLOBAL_LOGGER as logger
 
 
 class TestTask:

--- a/dbt/tracking.py
+++ b/dbt/tracking.py
@@ -1,7 +1,9 @@
 
+from dbt.logger import GLOBAL_LOGGER as logger
 from dbt import version as dbt_version
 from snowplow_tracker import Subject, Tracker, Emitter, logger as sp_logger
 from snowplow_tracker import SelfDescribingJson, disable_contracts
+
 disable_contracts()
 
 import platform
@@ -10,8 +12,6 @@ import yaml
 import os
 import json
 import logging
-
-logger = logging.getLogger(__name__)
 
 sp_logger.setLevel(100)
 
@@ -155,7 +155,7 @@ def track(*args, **kwargs):
     if __is_do_not_track:
         return
     else:
-        #logger.debug("Sending event: {}".format(kwargs))
+        logger.debug("Sending event: {}".format(kwargs))
         try:
             tracker.track_struct_event(*args, **kwargs)
         except Exception as e:
@@ -182,9 +182,10 @@ def track_invalid_invocation(project=None, args=None, result_type=None, result=N
     track(category="dbt", action='invocation', label='invalid', context=context)
 
 def flush():
+    logger.debug("Flushing usage events")
     tracker.flush()
 
 def do_not_track():
     global __is_do_not_track
-    logger.info("Not sending anonymous usage events")
+    logger.debug("Not sending anonymous usage events")
     __is_do_not_track = True

--- a/dbt/tracking.py
+++ b/dbt/tracking.py
@@ -1,4 +1,3 @@
-
 from dbt.logger import GLOBAL_LOGGER as logger
 from dbt import version as dbt_version
 from snowplow_tracker import Subject, Tracker, Emitter, logger as sp_logger

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -4,6 +4,7 @@ import dbt.project
 import pprint
 import json
 import dbt.project
+from dbt.logger import GLOBAL_LOGGER as logger
 
 DBTConfigKeys = [
     'enabled',

--- a/dbt/utils.py
+++ b/dbt/utils.py
@@ -39,7 +39,7 @@ def compiler_error(model, msg):
     raise RuntimeError("! Compilation error while compiling model {}:\n! {}".format(name, msg))
 
 def compiler_warning(model, msg):
-    print("* Compilation warning while compiling model {}:\n* {}".format(model.nice_name, msg))
+    logger.info("* Compilation warning while compiling model {}:\n* {}".format(model.nice_name, msg))
 
 class Var(object):
     UndefinedVarError = "Required var '{}' not found in config:\nVars supplied to {} = {}"
@@ -96,8 +96,8 @@ def dependency_projects(project):
             try:
                 yield dbt.project.read_project(os.path.join(full_obj, 'dbt_project.yml'), project.profiles_dir, profile_to_load=project.profile_to_load)
             except dbt.project.DbtProjectError as e:
-                print("Error reading dependency project at {}".format(full_obj))
-                print(str(e))
+                logger.info("Error reading dependency project at {}".format(full_obj))
+                logger.info(str(e))
 
 def split_path(path):
     norm = os.path.normpath(path)


### PR DESCRIPTION
This branch:

- Adds a `--debug` flag which prints dates and DEBUG level logs to the console during dbt runs. This will be useful for debugging.
- Removes all `print()` statements in favor of `logger...` calls.
- Removes writes to the `logs/` directory in favor of writing to standard out.