### PR TITLE
fix on-run-end hooks

### DIFF
--- a/dbt/runner.py
+++ b/dbt/runner.py
@@ -223,7 +223,7 @@ class ModelRunner(BaseRunner):
         self.__run_hooks(hooks, context, 'on-run-start hooks')
 
     def post_run_all(self, models, results, context):
-        hooks = self.project.cfg.get('on-run-start', [])
+        hooks = self.project.cfg.get('on-run-end', [])
         self.__run_hooks(hooks, context, 'on-run-end hooks')
 
 


### PR DESCRIPTION
fix for https://github.com/analyst-collective/dbt/issues/260

Previously, the `on-run-start` hooks were errantly run (instead of the `on-run-end` hooks) at the end of a dbt run