### PR TITLE
log exception and error level output at debug

### DIFF
--- a/dbt/runner.py
+++ b/dbt/runner.py
@@ -435,7 +435,7 @@ class RunManager(object):
             error = "Error executing {filepath}\n{error}".format(
                 filepath=model['build_path'], error=str(e).strip())
             status = "ERROR"
-            logger.exception(error)
+            logger.debug(error)
             if type(e) == psycopg2.InternalError and \
                ABORTED_TRANSACTION_STRING == e.diag.message_primary:
                 return RunModelResult(
@@ -444,7 +444,7 @@ class RunManager(object):
             error = ("Unhandled error while executing {filepath}\n{error}"
                      .format(
                          filepath=model['build_path'], error=str(e).strip()))
-            logger.exception(error)
+            logger.debug(error)
             raise e
 
         execution_time = time.time() - start_time

--- a/dbt/schema.py
+++ b/dbt/schema.py
@@ -150,7 +150,7 @@ class Schema(object):
                     return cursor.statusmessage
                 except Exception as e:
                     self.target.rollback()
-                    logger.exception("Error running SQL: %s", sql)
+                    logger.debug("Error running SQL: %s", sql)
                     logger.debug("rolling back connection")
                     raise e
 
@@ -170,7 +170,7 @@ class Schema(object):
                     return data
                 except Exception as e:
                     self.target.rollback()
-                    logger.exception("Error running SQL: %s", sql)
+                    logger.debug("Error running SQL: %s", sql)
                     logger.debug("rolling back connection")
                     raise e
 
@@ -207,7 +207,7 @@ class Schema(object):
             return handle, cursor.statusmessage
         except Exception as e:
             self.target.rollback()
-            logger.exception("Error running SQL: %s", sql)
+            logger.debug("Error running SQL: %s", sql)
             logger.debug("rolling back connection")
             raise e
         finally:

--- a/dbt/schema_tester.py
+++ b/dbt/schema_tester.py
@@ -89,18 +89,18 @@ class SchemaTester(object):
                         "SQL status: %s in %d seconds",
                         cursor.statusmessage, post-pre)
                 except psycopg2.ProgrammingError as e:
-                    logger.exception('programming error: %s', sql)
+                    logger.debug('programming error: %s', sql)
                     return e.diag.message_primary
                 except Exception as e:
-                    logger.exception(
+                    logger.debug(
                         'encountered exception while running: %s', sql)
                     e.model = model
                     raise e
 
                 result = cursor.fetchone()
                 if len(result) != 1:
-                    logger.error("SQL: %s", sql)
-                    logger.error("RESULT: %s", result)
+                    logger.debug("SQL: %s", sql)
+                    logger.debug("RESULT: %s", result)
                     raise RuntimeError(
                         "Unexpected validation result. Expected 1 record, "
                         "got {}".format(len(result)))

--- a/dbt/tracking.py
+++ b/dbt/tracking.py
@@ -175,7 +175,7 @@ def track(*args, **kwargs):
         try:
             tracker.track_struct_event(*args, **kwargs)
         except Exception as e:
-            logger.exception(
+            logger.debug(
                 "An error was encountered while trying to send an event"
             )
 


### PR DESCRIPTION
unclutters dbt output by not logging all the sql to stdout.