### PR TITLE
add a simple set of graph unit tests for models only

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5
+FROM python:3.6
 
 RUN apt-get update
 

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@
 
 changed_tests := `git status --porcelain | grep '^\(M\| M\|A\| A\)' | awk '{ print $$2 }' | grep '\/test_[a-zA-Z_\-\.]\+.py'`
 
+it:
+	@echo "Unit test run starting..."
+	@time docker-compose run test tox -e unit-py27,pep8
+
 test:
 	@echo "Full test run starting..."
 	@time docker-compose run test tox

--- a/dbt/clients/system.py
+++ b/dbt/clients/system.py
@@ -2,6 +2,7 @@ import fnmatch
 import os
 import os.path
 
+
 def find_matching(root_path,
                   relative_paths_to_search,
                   file_pattern):
@@ -41,8 +42,12 @@ def find_matching(root_path,
 
     return matching
 
-def load_file_contents(path):
-    with open(path, 'r') as handle:
-        to_return = handle.read()
 
-    return to_return.strip()
+def load_file_contents(path, strip=True):
+    with open(path, 'rb') as handle:
+        to_return = handle.read().decode('utf-8')
+
+    if strip:
+        to_return = to_return.strip()
+
+    return to_return

--- a/dbt/clients/system.py
+++ b/dbt/clients/system.py
@@ -1,0 +1,48 @@
+import fnmatch
+import os
+import os.path
+
+def find_matching(root_path,
+                  relative_paths_to_search,
+                  file_pattern):
+    """
+    Given an absolute `root_path`, a list of relative paths to that
+    absolute root path (`relative_paths_to_search`), and a `file_pattern`
+    like '*.sql', returns information about the files. For example:
+
+    > find_matching('/root/path', 'models', '*.sql')
+
+      [ { 'absolute_path': '/root/path/models/model_one.sql',
+          'relative_path': 'models/model_one.sql',
+          'searched_path': 'models' },
+        { 'absolute_path': '/root/path/models/subdirectory/model_two.sql',
+          'relative_path': 'models/subdirectory/model_two.sql',
+          'searched_path': 'models' } ]
+    """
+    matching = []
+
+    for relative_path_to_search in relative_paths_to_search:
+        absolute_path_to_search = os.path.join(
+            root_path, relative_path_to_search)
+        walk_results = os.walk(absolute_path_to_search)
+
+        for current_path, subdirectories, local_files in walk_results:
+            for local_file in local_files:
+                absolute_path = os.path.join(current_path, local_file)
+                relative_path = os.path.relpath(
+                    absolute_path, absolute_path_to_search)
+
+                if fnmatch.fnmatch(local_file, file_pattern):
+                    matching.append({
+                        'searched_path': relative_path_to_search,
+                        'absolute_path': absolute_path,
+                        'relative_path': relative_path,
+                    })
+
+    return matching
+
+def load_file_contents(path):
+    with open(path, 'r') as handle:
+        to_return = handle.read()
+
+    return to_return.strip()

--- a/dbt/compilation.py
+++ b/dbt/compilation.py
@@ -274,7 +274,7 @@ class Compiler(object):
             jinja = jinja2.Environment(loader=fs_loader)
 
             template_contents = dbt.clients.system.load_file_contents(
-                model.filepath)
+                model.absolute_path)
 
             template = jinja.from_string(template_contents)
             context = self.get_context(

--- a/dbt/compilation.py
+++ b/dbt/compilation.py
@@ -6,10 +6,11 @@ import time
 import sqlparse
 
 import dbt.project
+import dbt.utils
+
 from dbt.source import Source
 from dbt.utils import find_model_by_fqn, find_model_by_name, \
-    dependency_projects, split_path, This, Var, compiler_error, \
-    to_string
+     split_path, This, Var, compiler_error, to_string
 
 from dbt.linker import Linker
 from dbt.runtime import RuntimeContext
@@ -229,7 +230,7 @@ class Compiler(object):
 
         return wrapped_do_ref
 
-    def get_context(self, linker, model,  models, add_dependency=False):
+    def get_context(self, linker, model, models, add_dependency=False):
         runtime = RuntimeContext(model=model)
 
         context = self.project.context()
@@ -272,10 +273,10 @@ class Compiler(object):
             fs_loader = jinja2.FileSystemLoader(searchpath=model.root_dir)
             jinja = jinja2.Environment(loader=fs_loader)
 
-            # this is a dumb jinja2 bug -- on windows, forward slashes
-            # are EXPECTED
-            posix_filepath = '/'.join(split_path(model.rel_filepath))
-            template = jinja.get_template(posix_filepath)
+            template_contents = dbt.clients.system.load_file_contents(
+                model.filepath)
+
+            template = jinja.from_string(template_contents)
             context = self.get_context(
                 linker, model, models, add_dependency=add_dependency
             )
@@ -521,7 +522,7 @@ class Compiler(object):
 
     def get_models(self):
         all_models = self.model_sources(this_project=self.project)
-        for project in dependency_projects(self.project):
+        for project in dbt.utils.dependency_projects(self.project):
             all_models.extend(
                 self.model_sources(
                     this_project=self.project, own_project=project
@@ -536,7 +537,7 @@ class Compiler(object):
         all_models = self.get_models()
         all_macros = self.get_macros(this_project=self.project)
 
-        for project in dependency_projects(self.project):
+        for project in dbt.utils.dependency_projects(self.project):
             all_macros.extend(
                 self.get_macros(this_project=self.project, own_project=project)
             )

--- a/dbt/model.py
+++ b/dbt/model.py
@@ -202,6 +202,10 @@ class DBTSource(object):
         self.source_config = SourceConfig(project, own_project, self.fqn)
 
     @property
+    def absolute_path(self):
+        return os.path.join(self.root_dir, self.rel_filepath)
+
+    @property
     def root_dir(self):
         return os.path.join(self.own_project['project-root'], self.top_dir)
 
@@ -229,7 +233,7 @@ class DBTSource(object):
 
     @property
     def contents(self):
-        return dbt.clients.system.load_file_contents(self.filepath)
+        return dbt.clients.system.load_file_contents(self.absolute_path)
 
     @property
     def config(self):

--- a/dbt/model.py
+++ b/dbt/model.py
@@ -1,4 +1,3 @@
-
 import os.path
 import yaml
 import jinja2
@@ -10,6 +9,7 @@ import dbt.project
 import dbt.archival
 from dbt.utils import deep_merge, DBTConfigKeys, compiler_error, \
     compiler_warning
+
 
 class SourceConfig(object):
     Materializations = ['view', 'table', 'incremental', 'ephemeral']

--- a/dbt/model.py
+++ b/dbt/model.py
@@ -11,7 +11,6 @@ import dbt.archival
 from dbt.utils import deep_merge, DBTConfigKeys, compiler_error, \
     compiler_warning
 
-
 class SourceConfig(object):
     Materializations = ['view', 'table', 'incremental', 'ephemeral']
     ConfigKeys = DBTConfigKeys
@@ -230,9 +229,7 @@ class DBTSource(object):
 
     @property
     def contents(self):
-        filepath = os.path.join(self.root_dir, self.rel_filepath)
-        with open(filepath) as fh:
-            return fh.read().strip()
+        return dbt.clients.system.load_file_contents(self.filepath)
 
     @property
     def config(self):

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,5 +1,4 @@
 nose>=1.3.7
-nosy>=1.1.2
 mock>=1.3.0
 pep8>=1.6.2
 bumpversion==0.5.3

--- a/test/integration/006_simple_dependency_test/test_simple_dependency_with_configs.py
+++ b/test/integration/006_simple_dependency_test/test_simple_dependency_with_configs.py
@@ -91,8 +91,7 @@ class TestSimpleDependencyWithModelSpecificOverriddenConfigs(BaseTestSimpleDepen
                         "vars": {
                             "config_1": "ghi",
                             "config_2": "jkl",
-                            "bool_config": True
-
+                            "bool_config": True,
                         }
                     }
                 }

--- a/test/integration/009_data_tests_test/test_data_tests.py
+++ b/test/integration/009_data_tests_test/test_data_tests.py
@@ -43,7 +43,6 @@ class TestDataTests(DBTIntegrationTest):
         self.run_dbt()
         test_results = self.run_data_validations()
 
-
         for result in test_results:
             # assert that all deliberately failing tests actually fail
             if 'fail' in result.model.name:

--- a/test/unit/test_dependencies.py
+++ b/test/unit/test_dependencies.py
@@ -1,0 +1,108 @@
+from mock import MagicMock, patch, PropertyMock
+import unittest
+
+import dbt.model
+import dbt.project
+import dbt.templates
+import dbt.utils
+
+import networkx as nx
+
+import dbt.compilation
+
+from dbt.logger import GLOBAL_LOGGER as logger
+
+class DependencyTest(unittest.TestCase):
+    def setUp(self):
+        def mock_write_yaml(graph, outfile):
+            self.graph_result = graph
+
+        nx.write_yaml = mock_write_yaml
+        self.graph_result = None
+
+        self.profiles = {
+            'test': {
+                'outputs': {
+                    'test': {
+                        'type': 'postgres',
+                        'threads': 4,
+                        'host': 'database',
+                        'port': 5432,
+                        'user': 'root',
+                        'pass': 'password',
+                        'dbname': 'dbt',
+                        'schema': 'dbt_test'
+                    }
+                },
+                'target': 'test'
+            }
+        }
+
+        self.project = dbt.project.Project(
+            cfg={
+                'name': 'test_models_compile',
+                'version': '0.1',
+                'profile': 'test',
+                'project-root': '/fake',
+            },
+            profiles=self.profiles,
+            profiles_dir=None)
+
+        self.project.validate()
+
+        self.compiler = dbt.compilation.Compiler(
+            self.project,
+            dbt.templates.BaseCreateTemplate,
+            {})
+
+        self.compiler.get_macros = MagicMock(return_value=[])
+
+        dbt.utils.dependency_projects = MagicMock(return_value=[])
+
+
+    def use_models(self, models):
+        dbt.clients.system.find_matching = MagicMock(
+            return_value=[{'searched_path': 'models',
+                           'absolute_path': '/fake/models/{}.sql'.format(k),
+                           'relative_path': '{}.sql'.format(k)}
+                          for k, v in models.items()])
+
+        def mock_load_file_contents(path):
+            k = path.split('/')[-1].split('.')[0]
+            return models[k]
+
+        dbt.clients.system.load_file_contents = MagicMock(
+            side_effect=mock_load_file_contents)
+
+
+    def test_single_model(self):
+        self.use_models({
+            'model_one': 'select * from events',
+        })
+
+        self.compiler.compile(limit_to=['models'])
+
+        self.assertEquals(
+            self.graph_result.nodes(),
+            [('test_models_compile', 'model_one')])
+
+        self.assertEquals(
+            self.graph_result.edges(), [])
+
+    def test_two_models_simple_ref(self):
+        self.use_models({
+            'model_one': 'select * from events',
+            'model_two': "select * from {{ref('model_one')}}",
+        })
+
+        self.compiler.compile(limit_to=['models'])
+
+        self.assertEquals(
+            self.graph_result.nodes(),
+            [('test_models_compile', 'model_one'),
+             ('test_models_compile', 'model_two'),])
+
+        self.assertEquals(
+            self.graph_result.edges(),
+            [(('test_models_compile', 'model_one'),
+              ('test_models_compile', 'model_two')),])

--- a/test/unit/test_graph.py
+++ b/test/unit/test_graph.py
@@ -44,7 +44,7 @@ class GraphTest(unittest.TestCase):
                 'name': 'test_models_compile',
                 'version': '0.1',
                 'profile': 'test',
-                'project-root': '/fake',
+                'project-root': os.path.abspath('.'),
             },
             profiles=self.profiles,
             profiles_dir=None)
@@ -86,7 +86,7 @@ class GraphTest(unittest.TestCase):
 
     def use_models(self, models):
         for k, v in models.items():
-            path = os.path.abspath('/fake/models/{}.sql'.format(k))
+            path = os.path.abspath('models/{}.sql'.format(k))
             self.mock_models.append({
                 'searched_path': 'models',
                 'absolute_path': path,
@@ -105,7 +105,8 @@ class GraphTest(unittest.TestCase):
             [('test_models_compile', 'model_one')])
 
         self.assertEquals(
-            self.graph_result.edges(), [])
+            self.graph_result.edges(),
+            [])
 
     def test__two_models_simple_ref(self):
         self.use_models({

--- a/test/unit/test_graph.py
+++ b/test/unit/test_graph.py
@@ -12,7 +12,7 @@ import dbt.compilation
 
 from dbt.logger import GLOBAL_LOGGER as logger
 
-class DependencyTest(unittest.TestCase):
+class GraphTest(unittest.TestCase):
     def setUp(self):
         def mock_write_yaml(graph, outfile):
             self.graph_result = graph

--- a/test/unit/test_graph.py
+++ b/test/unit/test_graph.py
@@ -86,10 +86,10 @@ class GraphTest(unittest.TestCase):
 
     def use_models(self, models):
         for k, v in models.items():
-            path = '/fake/models/{}.sql'.format(k)
+            path = os.path.abspath('/fake/models/{}.sql'.format(k))
             self.mock_models.append({
                 'searched_path': 'models',
-                'absolute_path': os.path.abspath(path),
+                'absolute_path': path,
                 'relative_path': '{}.sql'.format(k)})
             self.mock_content[path] = v
 


### PR DESCRIPTION
Adds two very simple tests -- one that just compiles a model like `select * from table`, and one that tests a very simple reference. It took me a little while to get started on this. I'll add more tests shortly.

Related: https://github.com/analyst-collective/dbt/issues/230