### PR TITLE
add optional `role` argument, fix messaging around permissions errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## dbt 0.7.1 (unreleased)
+
+#### New Features
+
+- profiles.yml now supports Snowflake `role` as an option ([#291](https://github.com/analyst-collective/dbt/pull/291))
+
 ## dbt 0.7.0 (February 9, 2017)
 
 ### Overview

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 changed_tests := `git status --porcelain | grep '^\(M\| M\|A\| A\)' | awk '{ print $$2 }' | grep '\/test_[a-zA-Z_\-\.]\+.py'`
 
 install:
-	pip install .
+	pip install --upgrade .
 
 test:
 	@echo "Full test run starting..."

--- a/dbt/contracts/connection.py
+++ b/dbt/contracts/connection.py
@@ -1,4 +1,4 @@
-from voluptuous import Schema, Required, All, Any, Extra, Range
+from voluptuous import Schema, Required, All, Any, Extra, Range, Optional
 from voluptuous.error import MultipleInvalid
 
 from dbt.exceptions import ValidationException
@@ -28,6 +28,7 @@ snowflake_credentials_contract = Schema({
     Required('database'): str,
     Required('schema'): str,
     Required('warehouse'): str,
+    Optional('role'): str,
 })
 
 credentials_mapping = {

--- a/dbt/main.py
+++ b/dbt/main.py
@@ -104,7 +104,8 @@ def run_from_args(parsed):
         dbt.tracking.track_invocation_end(
             project=proj, args=parsed, result_type="ok", result=None
         )
-    except dbt.exceptions.NotImplementedException as e:
+    except (dbt.exceptions.NotImplementedException,
+            dbt.exceptions.FailedToConnectException) as e:
         logger.info('ERROR: {}'.format(e))
         dbt.tracking.track_invocation_end(
             project=proj, args=parsed, result_type="error", result=str(e)

--- a/sample.profiles.yml
+++ b/sample.profiles.yml
@@ -59,6 +59,8 @@ evil-corp:
                                   # i.e. evilcorp.snowflakecomputing.com
             user: elliot
             password: pa55word
+            role: SYSADMIN        # optional, the snowflake role you want to use
+                                  # when connecting
             database: db
             warehouse: warehouse
             schema: analytics     # use the prod schema instead


### PR DESCRIPTION
This branch adds an optional `role` argument to profiles.yml, and also improves the messaging around faux 'This session does not have a current database' (actually lack of permissions) errors.

Functionally tested with:

`role: INVALID` (invalid
`role: SYSADMIN` (valid, with CREATE permissions)
`role: PUBLIC` (valid, but not enough permissions)
no role (== SYSADMIN as that is my default role)